### PR TITLE
Enumerate all cluster hosts and pvelocalhost in a block (closes #11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
   PASS"; exit 0) || (echo "Idempotence: FAIL"; cat /tmp/idempotency.log; exit 1)'
 - ansible -m shell -a "journalctl --no-pager -xu pvedaemon.service" -i tests/inventory all
 - ansible -m shell -a "journalctl --no-pager -xu pve-cluster.service" -i tests/inventory all
-- ansible -m shell -a "cat /etc/hosts" -i tests/inventory all
 - ansible -m uri -a 'url=https://{{ inventory_hostname }}:8006 validate_certs=no' -i tests/inventory all
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   PASS"; exit 0) || (echo "Idempotence: FAIL"; cat /tmp/idempotency.log; exit 1)'
 - ansible -m shell -a "journalctl --no-pager -xu pvedaemon.service" -i tests/inventory all
 - ansible -m shell -a "journalctl --no-pager -xu pve-cluster.service" -i tests/inventory all
+- ansible -m shell -a "cat /etc/hosts" -i tests/inventory all
 - ansible -m uri -a 'url=https://{{ inventory_hostname }}:8006 validate_certs=no' -i tests/inventory all
 
 notifications:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
     msg: "Missing IP address and other information for {{ item }}. Have you gathered its facts?"
   with_items: "{{ groups[pve_group] }}"
 
+- debug: var=hostvars[item]
+  with_items: "{{ groups[pve_group] }}"
+
 - include: ssh_cluster_config.yml
 
 - name: Enumerate all cluster hosts within the hosts file
@@ -14,7 +17,10 @@
     marker: "# {mark} ANSIBLE MANAGED: Proxmox Cluster Hosts"
     content: |
       {% for host in groups[pve_group] %}
-      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}{% if ansible_fqdn == hostvars[host].ansible_fqdn %} pvelocalhost{% endif %}
+      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}
+      {% if ansible_fqdn == hostvars[host].ansible_fqdn %}
+       pvelocalhost
+      {% endif %}
       {% endfor %}
 
 - name: Trust Proxmox' packaging key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     marker: "# {mark} ANSIBLE MANAGED: Proxmox Cluster Hosts"
     content: |
       {% for host in groups[pve_group] %}
-      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}{% if ansible_fqdn == hostvars[host].ansible_fqdn %} pvelocalhost{% endif %}
       {% endfor %}
 
 - name: Trust Proxmox' packaging key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 # tasks file for ansible-role-proxmox
+- assert:
+    that:
+      - "hostvars[item].ansible_default_ipv4.address == True"
+    msg: "Missing IP address and other information for {{ item }}. Have you gathered its facts?"
+  with_items: "{{ groups[pve_group] }}"
+
 - include: ssh_cluster_config.yml
 
 - name: Enumerate all cluster hosts within the hosts file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,14 @@
 # tasks file for ansible-role-proxmox
 - include: ssh_cluster_config.yml
 
-- name: Ensure public IP is in /etc/hosts
-  lineinfile:
+- name: Enumerate all cluster hosts within the hosts file
+  blockinfile:
     dest: /etc/hosts
-    state: present
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
-    regexp: "{{ ansible_hostname }}"
+    marker: "# {mark} ANSIBLE MANAGED: Proxmox Cluster Hosts"
+    content: |
+      {% for host in groups[pve_group] %}
+      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
+      {% endfor %}
 
 - name: Trust Proxmox' packaging key
   apt_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ansible-role-proxmox
 - assert:
     that:
-      - "hostvars[item].ansible_default_ipv4.address == True"
+      - "hostvars[item].ansible_default_ipv4.address is defined"
     msg: "Missing IP address and other information for {{ item }}. Have you gathered its facts?"
   with_items: "{{ groups[pve_group] }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,6 @@
     msg: "Missing IP address and other information for {{ item }}. Have you gathered its facts?"
   with_items: "{{ groups[pve_group] }}"
 
-- debug: var=hostvars[item]
-  with_items: "{{ groups[pve_group] }}"
-
 - include: ssh_cluster_config.yml
 
 - name: Enumerate all cluster hosts within the hosts file
@@ -17,10 +14,8 @@
     marker: "# {mark} ANSIBLE MANAGED: Proxmox Cluster Hosts"
     content: |
       {% for host in groups[pve_group] %}
-      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}
-      {% if ansible_fqdn == hostvars[host].ansible_fqdn %}
-       pvelocalhost
-      {% endif %}
+      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}{% if ansible_fqdn == hostvars[host].ansible_fqdn %} pvelocalhost{% endif %}
+
       {% endfor %}
 
 - name: Trust Proxmox' packaging key


### PR DESCRIPTION
Resolves #11 

NOTE: The original line may be present on existing installations but shouldn't pose much issue (as the block would be placed underneath). If wanted, users can use the following ad-hoc command to clean /etc/hosts from the previous lineinfile task:

    ansible -i inventory all -m lineinfile -a "dest=/etc/hosts state=absent regexp="^{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}$"'

(and any become/ask params as needed)