### PR TITLE
Add logic for managing users and groups in PVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ pve_watchdog_ipmi_action: power_cycle # Can be one of "reset", "power_cycle", an
 pve_watchdog_ipmi_timeout: 10 # Number of seconds the watchdog should wait
 # pve_ssl_private_key: "" # Should be set to the contents of the private key to use for HTTPS
 # pve_ssl_certificate: "" # Should be set to the contents of the certificate to use for HTTPS
+pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
+pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 ```
 
 To enable clustering with this role, configure the following variables appropriately:
@@ -130,6 +132,47 @@ requires that the `jmespath` library be installed on your control host. You can
 either `pip install jmespath` or install it via your distribution's package
 manager, e.g. `apt-get install python-jmespath`.
 
+User Management
+---------------
+
+You can use this role to manage users and groups within Proxmox VE (both in
+single server deployments and cluster deployments). Here are some examples.
+
+```
+pve_groups:
+  - name: Admins
+    comment: Administrators of this PVE cluster
+  - name: api_users
+  - name: test_users
+pve_users:
+  - name: root@pam
+    email: postmaster@pve.example
+  - name: lae@pam
+    email: lae@pve.example
+    firstname: Musee
+    lastname: Ullah
+    groups: [ "Admins" ]
+  - name: pveapi@pve
+    password: "Proxmox789"
+    groups:
+      - api_users
+  - name: testapi@pve
+    password: "Test456"
+    enable: no
+    groups:
+      - api_users
+      - test_users
+  - name: tempuser@pam
+    expire: 1514793600
+    groups: [ "test_users" ]
+    comment: "Temporary user set to expire on 2018年  1月  1日 月曜日 00:00:00 PST"
+    email: tempuser@pve.example
+    firstname: Test
+    lastname: User
+```
+
+Refer to `library/proxmox_user.py` [link][user-module] and
+`library/proxmox_group.py` [link][group-module] for module documentation.
 
 License
 -------
@@ -144,3 +187,5 @@ Musee Ullah <musee.ullah@fireeye.com>
 [pve-cluster]: https://pve.proxmox.com/wiki/Proxmox_VE_4.x_Cluster
 [install-ansible]: http://docs.ansible.com/ansible/intro_installation.html
 [pvecm-network]: https://pve.proxmox.com/pve-docs/chapter-pvecm.html#_separate_cluster_network
+[user-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_user.py
+[group-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_group.py

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,5 @@ pve_cluster_ring0_addr: "{{ ansible_default_ipv4.address }}"
 pve_cluster_bindnet0_addr: "{{ pve_cluster_ring0_addr }}"
 # pve_cluster_ring1_addr: "another interface's IP address or hostname"
 # pve_cluster_bindnet1_addr: "{{ pve_cluster_ring1_addr }}"
+pve_groups: []
 pve_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,4 @@ pve_cluster_ring0_addr: "{{ ansible_default_ipv4.address }}"
 pve_cluster_bindnet0_addr: "{{ pve_cluster_ring0_addr }}"
 # pve_cluster_ring1_addr: "another interface's IP address or hostname"
 # pve_cluster_bindnet1_addr: "{{ pve_cluster_ring1_addr }}"
+pve_users: []

--- a/library/proxmox_group.py
+++ b/library/proxmox_group.py
@@ -14,12 +14,20 @@ short_description: Manages groups in Proxmox
 
 options:
     name:
-        description:
-            - Group name
         required: true
-    comment:
+        aliases: [ "group", "groupid" ]
         description:
-            - Group comment
+            - Name of the PVE group to manager.
+    state:
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Specifies whether the group should exist or not.
+    comment:
+        required: false
+        description:
+            - Optionally sets the group's comment in PVE.
 
 author:
     - Musee Ullah (@lae)

--- a/library/proxmox_group.py
+++ b/library/proxmox_group.py
@@ -90,7 +90,7 @@ class ProxmoxGroup(object):
         changes_needed = False
 
         for key in updated_group:
-            if updated_group[key].replace('\ ', ' ') != current_group[key]:
+            if key not in current_group or updated_group[key].replace('\ ', ' ') != current_group[key]:
                 changes_needed = True
 
         if self.module.check_mode and changes_needed:

--- a/library/proxmox_group.py
+++ b/library/proxmox_group.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
@@ -53,6 +54,7 @@ group:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 from ansible.module_utils.pvesh import ProxmoxShellError
 import ansible.module_utils.pvesh as pvesh
 
@@ -98,7 +100,8 @@ class ProxmoxGroup(object):
         error = None
 
         for key in staged_group:
-            if key not in lookup or staged_group[key] != lookup[key]:
+            staged_value = to_text(staged_group[key]) if isinstance(staged_group[key], str) else staged_group[key]
+            if key not in lookup or staged_value != lookup[key]:
                 updated_fields.append(key)
 
         if self.module.check_mode:

--- a/library/proxmox_group.py
+++ b/library/proxmox_group.py
@@ -101,8 +101,8 @@ class ProxmoxGroup(object):
             if key not in lookup or staged_group[key] != lookup[key]:
                 updated_fields.append(key)
 
-        if self.module.check_mode and updated_fields:
-            self.module.exit_json(changed=True, expected_changes=updated_fields)
+        if self.module.check_mode:
+            self.module.exit_json(changed=bool(updated_fields), expected_changes=updated_fields)
 
         if not updated_fields:
             # No changes necessary

--- a/library/proxmox_group.py
+++ b/library/proxmox_group.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'lae'
+}
+
+DOCUMENTATION = '''
+---
+module: proxmox_group
+
+short_description: Manages groups in Proxmox
+
+options:
+    name:
+        description:
+            - Group name
+        required: true
+    comment:
+        description:
+            - Group comment
+
+author:
+    - Musee Ullah (@lae)
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from proxmoxer import ProxmoxAPI
+
+class ProxmoxGroup(object):
+    def __init__(self, module):
+        self.module = module
+        self.name = module.params['name']
+        self.state = module.params['state']
+        self.comment = module.params['comment']
+
+        self.cluster = ProxmoxAPI(backend='local')
+
+    def group_exists(self):
+        try:
+            if self.cluster.access.groups.get(self.name):
+                return True
+        except:
+            return False
+
+    def group_info(self):
+        if not self.group_exists():
+            return False
+        return self.cluster.access.groups.get(self.name)
+
+    def remove_group(self):
+        try:
+            self.cluster.access.groups.delete(self.name)
+            return (True, None)
+        except:
+            return (False, "Failed to run pvesh delete for group.")
+
+    def create_group(self):
+        new_group = {}
+        if self.comment is not None:
+            new_group['comment'] = self.comment.replace(' ', '\ ')
+
+        try:
+            self.cluster.access.groups.create(groupid=self.name, **new_group)
+            return (True, None)
+        except:
+            return (False, "Failed to run pvesh create for this group.")
+
+    def modify_group(self):
+        current_group = self.group_info()
+        updated_group = {}
+        if self.comment is not None:
+            updated_group['comment'] = self.comment.replace(' ', '\ ')
+
+        changes_needed = False
+
+        for key in updated_group:
+            if updated_group[key].replace('\ ', ' ') != current_group[key]:
+                changes_needed = True
+
+        if self.module.check_mode and changes_needed:
+            self.module.exit_json(changed=True)
+
+        if not changes_needed:
+            # No changes necessary
+            return (False, None)
+
+        try:
+            self.cluster.access.groups(self.name).put(**updated_group)
+            return (True, None)
+        except:
+            return (False, "Failed to run pvesh create for this group.")
+
+def main():
+    # Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html
+    module = AnsibleModule(
+        argument_spec = dict(
+            name=dict(type='str', required=True, aliases=['group', 'groupid']),
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            comment=dict(default=None, type='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    group = ProxmoxGroup(module)
+
+    changed = False
+    error = None
+    result = {}
+    result['name'] = group.name
+    result['state'] = group.state
+
+    if group.state == 'absent':
+        if group.group_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (changed, error) = group.remove_group()
+            if error is not None:
+                module.fail_json(name=group.name, msg=error)
+    elif group.state == 'present':
+        if not group.group_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (changed, error) = group.create_group()
+        else:
+            # modify group (note: this function is check mode aware)
+            (changed, err) = group.modify_group()
+        if error is not None:
+            module.fail_json(name=group.name, msg=error)
+
+    if group.group_exists():
+        result['group'] = group.group_info()
+
+    result['changed'] = changed
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 ANSIBLE_METADATA = {
     'metadata_version': '0.2',
@@ -117,6 +118,7 @@ user:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 from ansible.module_utils.pvesh import ProxmoxShellError
 import ansible.module_utils.pvesh as pvesh
 
@@ -210,7 +212,8 @@ class ProxmoxUser(object):
                 if set(self.groups) != set(lookup['groups']):
                     updated_fields.append(key)
             else:
-                if key not in lookup or staged_user[key] != lookup[key]:
+                staged_value = to_text(staged_user[key]) if isinstance(staged_user[key], str) else staged_user[key]
+                if key not in lookup or staged_value != lookup[key]:
                     updated_fields.append(key)
 
         if self.module.check_mode:

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -179,7 +179,7 @@ class ProxmoxUser(object):
             else:
                 # honestly get rid of this cruft either by fixing proxmoxer or removing it as a dep/embedding pvesh commands in here directly
                 update = updated_user[key].replace('\ ', ' ') if type(updated_user[key]) is str else updated_user[key]
-                if update != current_user[key]:
+                if key not in current_user or update != current_user[key]:
                     changes_needed = True
 
         if self.module.check_mode and changes_needed:

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -120,7 +120,7 @@ class ProxmoxUser(object):
 
         for key in updated_user:
             if key == 'groups':
-                if self.groups != current_user['groups']:
+                if set(self.groups) != set(current_user['groups']):
                     changes_needed = True
             else:
                 # honestly get rid of this cruft either by fixing proxmoxer or removing it as a dep/embedding pvesh commands in here directly

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -14,9 +14,63 @@ short_description: Manages user accounts in Proxmox
 
 options:
     name:
-        description:
-            - User ID
         required: true
+        aliases: [ "user", "userid" ]
+        description:
+            - Name and realm of the user to create, e.g. C(operator@pam) and
+              C(pveapi@pve).
+    state:
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Specifies whether the user should exist or not.
+    enable:
+        required: false
+        default: yes
+        type: bool
+        description:
+            - Whether or not the user should be enabled in PVE.
+    groups:
+        required: false
+        type: list
+        description:
+            - Specifies a list of PVE groups that this user should belong to.
+    comment:
+        required: false
+        description:
+            - Optionally sets the user's comment in PVE.
+    email:
+        required: false
+        description:
+            - Optionally sets the user's email in PVE.
+    firstname:
+        required: false
+        description:
+            - Optionally sets the user's first name in PVE.
+    lastname:
+        required: false
+        description:
+            - Optionally sets the user's last name in PVE.
+    firstname:
+        required: false
+        description:
+            - Optionally sets the user's first name in PVE.
+    password:
+        required: false
+        description:
+            - Optionally sets the user's password in PVE. Note that this is only
+              used during the creation of a user to specify their initial
+              password, thus cannot be used to change a password of a user that
+              already exists (due to a limitation of the API, I believe). This
+              also only applies to the C(pve) realm as well, probably.
+    expire:
+        required: false
+        default: 0
+        type: int
+        description:
+            - Account expiration date (seconds since epoch). C(0) means no
+              expiration date.
 
 author:
     - Musee Ullah (@lae)

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -123,7 +123,9 @@ class ProxmoxUser(object):
                 if self.groups != current_user['groups']:
                     changes_needed = True
             else:
-                if updated_user[key].replace('\ ', ' ') != current_user[key]:
+                # honestly get rid of this cruft either by fixing proxmoxer or removing it as a dep/embedding pvesh commands in here directly
+                update = updated_user[key].replace('\ ', ' ') if type(updated_user[key]) is str else updated_user[key]
+                if update != current_user[key]:
                     changes_needed = True
 
         if self.module.check_mode and changes_needed:

--- a/library/proxmox_user.py
+++ b/library/proxmox_user.py
@@ -85,9 +85,6 @@ class ProxmoxUser(object):
         if self.email is not None:
             args['email'] = self.email
 
-        if self.password is not None:
-            args['password'] = self.password.replace(' ', '\ ')
-
         if self.groups is not None:
             args['groups'] = ','.join(self.groups)
 
@@ -103,6 +100,9 @@ class ProxmoxUser(object):
     def create_user(self):
         new_user = self.prepare_user_args()
 
+        if self.password is not None:
+            new_user['password'] = self.password.replace(' ', '\ ')
+
         if not self.check_groups_exist():
             return (False, "One or more specified groups do not exist.")
 
@@ -113,9 +113,6 @@ class ProxmoxUser(object):
             return (False, "Failed to run pvesh create for this user.")
 
     def modify_user(self):
-        # We can't compare the password of an existing user
-        self.password = None
-
         current_user = self.user_info()
         updated_user = self.prepare_user_args()
 
@@ -158,7 +155,7 @@ def main():
             expire=dict(default=0, type='int'),
             firstname=dict(default=None, type='str'),
             lastname=dict(default=None, type='str'),
-            password=dict(default=None, type='str')
+            password=dict(default=None, type='str', no_log=True)
         ),
         supports_check_mode=True
     )

--- a/module_utils/pvesh.py
+++ b/module_utils/pvesh.py
@@ -23,15 +23,15 @@ def run_command(handler, path, **params):
         handler,
         path]
     for parameter, value in params.iteritems():
-        command += ["-{}".format(parameter), value]
+        command += ["-{}".format(parameter), "{}".format(value)]
 
     pipe = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (result, stderr) = pipe.communicate()
     stderr = stderr.splitlines()
 
     if stderr[0] == "200 OK":
-        if result == "":
-            result = None
+        if not result:
+            return {u"status": 200}
 
         # Attempt to marshall the data into JSON
         try:

--- a/module_utils/pvesh.py
+++ b/module_utils/pvesh.py
@@ -75,3 +75,21 @@ def get(path):
         return response["data"]
 
     raise ProxmoxShellError(response)
+
+def delete(path):
+    response = run_command("delete", path)
+
+    if response["status"] != 200:
+        raise ProxmoxShellError(response)
+
+def create(path, **params):
+    response = run_command("create", path, **params)
+
+    if response["status"] != 200:
+        raise ProxmoxShellError(response)
+
+def set(path, **params):
+    response = run_command("set", path, **params)
+
+    if response["status"] != 200:
+        raise ProxmoxShellError(response)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,12 @@
 - include: pve_cluster_config.yml
   when: pve_cluster_enabled
 
+- name: Configure Proxmox user accounts
+  proxmox_user:
+  args: "{{ item }}"
+  with_items: "{{ pve_users }}"
+  when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
+
 - include: ssl_config.yml
   when:
     - pve_ssl_private_key is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,12 @@
 - include: pve_cluster_config.yml
   when: pve_cluster_enabled
 
+- name: Configure Proxmox groups
+  proxmox_group:
+  args: "{{ item }}"
+  with_items: "{{ pve_groups }}"
+  when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
+
 - name: Configure Proxmox user accounts
   proxmox_user:
   args: "{{ item }}"

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -6,14 +6,23 @@ pve_watchdog: ipmi
 pve_ssl_private_key: "{{ lookup('file', ssl_host_key_path) }}"
 pve_ssl_certificate: "{{ lookup('file', ssl_host_cert_path) }}"
 pve_cluster_enabled: yes
+pve_groups:
+  - name: testgroup
+  - name: anothertestgroup
+    comment: with a comment
 pve_users:
   - name: testuser@pam
     comment: "What a wonderful world."
     email: "user@example.invalid"
     firstname: Test
     lastname: User
+    groups:
+      - testgroup
+      - anothertestgroup
   - name: testuser@pve
     password: testpass
+    groups:
+      - testgroup
 
 ssl_directory: /home/travis/ssl/
 ssl_ca_key_path: "{{ ssl_directory }}/test-ca.key"

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -7,22 +7,35 @@ pve_ssl_private_key: "{{ lookup('file', ssl_host_key_path) }}"
 pve_ssl_certificate: "{{ lookup('file', ssl_host_cert_path) }}"
 pve_cluster_enabled: yes
 pve_groups:
-  - name: testgroup
-  - name: anothertestgroup
-    comment: with a comment
+  - name: Admins
+    comment: Administrators of this PVE cluster
+  - name: api_users
+  - name: test_users
 pve_users:
-  - name: testuser@pam
-    comment: "What a wonderful world."
-    email: "user@example.invalid"
+  - name: root@pam
+    email: postmaster@pve.example
+  - name: lae@pam
+    email: lae@pve.example
+    firstname: Musee
+    lastname: Ullah
+    groups: [ "Admins" ]
+  - name: pveapi@pve
+    password: "Proxmox789"
+    groups:
+      - api_users
+  - name: testapi@pve
+    password: "Test456"
+    enable: no
+    groups:
+      - api_users
+      - test_users
+  - name: tempuser@pam
+    expire: 1514793600
+    groups: [ "test_users" ]
+    comment: "Temporary user set to expire on 2018年  1月  1日 月曜日 00:00:00 PST"
+    email: tempuser@pve.example
     firstname: Test
     lastname: User
-    groups:
-      - testgroup
-      - anothertestgroup
-  - name: testuser@pve
-    password: testpass
-    groups:
-      - testgroup
 
 ssl_directory: /home/travis/ssl/
 ssl_ca_key_path: "{{ ssl_directory }}/test-ca.key"

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -6,6 +6,14 @@ pve_watchdog: ipmi
 pve_ssl_private_key: "{{ lookup('file', ssl_host_key_path) }}"
 pve_ssl_certificate: "{{ lookup('file', ssl_host_cert_path) }}"
 pve_cluster_enabled: yes
+pve_users:
+  - name: testuser@pam
+    comment: "What a wonderful world."
+    email: "user@example.invalid"
+    firstname: Test
+    lastname: User
+  - name: testuser@pve
+    password: testpass
 
 ssl_directory: /home/travis/ssl/
 ssl_ca_key_path: "{{ ssl_directory }}/test-ca.key"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,6 +13,15 @@
         that: "(__pve_cluster.stdout | from_json | json_query(query)) == 1"
       vars:
         query: "([?type=='cluster'].quorate)[0]"
+    - name: Query PVE users
+      shell: "pvesh get /access/users"
+      register: __pve_users
+      changed_when: False
+    - name: Check that PVE users exist
+      assert:
+        that: "(__pve_users.stdout | to_json | json_query(query)) == 1"
+      vars:
+        query: "length([?userid=={{ item.name }}])"
     - block:
       - name: pvedaemon service status
         shell: "journalctl --no-pager -xu pvedaemon.service"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,15 +13,28 @@
         that: "(__pve_cluster.stdout | from_json | json_query(query)) == 1"
       vars:
         query: "([?type=='cluster'].quorate)[0]"
+    - name: Query PVE groups
+      shell: "pvesh get /access/groups"
+      register: __pve_groups
+      changed_when: False
+    - name: Check that PVE groups exist
+      assert:
+        that: "(__pve_groups.stdout | from_json | json_query(query)) == 1"
+      vars:
+        query: "length([?groupid=={{ item.name }}])"
+      run_once: True
+      with_items: "{{ pve_groups }}"
     - name: Query PVE users
       shell: "pvesh get /access/users"
       register: __pve_users
       changed_when: False
     - name: Check that PVE users exist
       assert:
-        that: "(__pve_users.stdout | to_json | json_query(query)) == 1"
+        that: "(__pve_users.stdout | from_json | json_query(query)) == 1"
       vars:
         query: "length([?userid=={{ item.name }}])"
+      run_once: True
+      with_items: "{{ pve_users }}"
     - block:
       - name: pvedaemon service status
         shell: "journalctl --no-pager -xu pvedaemon.service"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -21,7 +21,7 @@
       assert:
         that: "(__pve_groups.stdout | from_json | json_query(query)) == 1"
       vars:
-        query: "length([?groupid=={{ item.name }}])"
+        query: "length([?groupid=='{{ item.name }}'])"
       run_once: True
       with_items: "{{ pve_groups }}"
     - name: Query PVE users
@@ -32,7 +32,7 @@
       assert:
         that: "(__pve_users.stdout | from_json | json_query(query)) == 1"
       vars:
-        query: "length([?userid=={{ item.name }}])"
+        query: "length([?userid=='{{ item.name }}'])"
       run_once: True
       with_items: "{{ pve_users }}"
     - block:


### PR DESCRIPTION
This adds `proxmox_user` and `proxmox_group` modules for creating and managing users and groups in PVE. It is cluster-aware and will only run once per cluster if being ran with `pve_cluster_enabled` set to yes/True.

These are defined through the role variables `pve_groups` and `pve_users`.