### PR TITLE
Add logic for managing ACLs in Proxmox

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ requires that the `jmespath` library be installed on your control host. You can
 either `pip install jmespath` or install it via your distribution's package
 manager, e.g. `apt-get install python-jmespath`.
 
-User Management
+User and ACL Management
 ---------------
 
 You can use this role to manage users and groups within Proxmox VE (both in
@@ -174,6 +174,24 @@ pve_users:
 Refer to `library/proxmox_user.py` [link][user-module] and
 `library/proxmox_group.py` [link][group-module] for module documentation.
 
+For managing ACLs, a similar module is employed, but the main difference is that
+most of the parameters only accept lists (subject to change):
+
+```
+pve_acls:
+  - path: /
+    roles: [ "Administrator" ]
+    groups: [ "Admins" ]
+  - path: /pools/testpool
+    roles: [ "PVEAdmin" ]
+    users:
+      - pveapi@pve
+    groups:
+      - test_users
+```
+
+Refer to `library/proxmox_acl.py` [link][acl-module] for module documentation.
+
 License
 -------
 
@@ -189,3 +207,4 @@ Musee Ullah <musee.ullah@fireeye.com>
 [pvecm-network]: https://pve.proxmox.com/pve-docs/chapter-pvecm.html#_separate_cluster_network
 [user-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_user.py
 [group-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_group.py
+[acl-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_group.py

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,4 @@ pve_cluster_bindnet0_addr: "{{ pve_cluster_ring0_addr }}"
 # pve_cluster_bindnet1_addr: "{{ pve_cluster_ring1_addr }}"
 pve_groups: []
 pve_users: []
+pve_acls: []

--- a/library/proxmox_acl.py
+++ b/library/proxmox_acl.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'lae'
+}
+
+DOCUMENTATION = '''
+---
+module: proxmox_acl
+
+short_description: Manages the Access Control List in Proxmox
+
+options:
+    path:
+        required: true
+        aliases: [ "resource" ]
+        description:
+            - Location of the resource to apply access control to.
+    roles:
+        required: true
+        type: list
+        description:
+            - Specifies a list of PVE roles, which contains sets of privileges,
+              to allow for this access control.
+    state:
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Specifies whether this access control should exist or not.
+    groups:
+        required: false
+        type: list
+        description:
+            - Specifies a list of PVE groups to apply this access control for.
+    users:
+        required: false
+        type: list
+        description:
+            - Specifies a list of PVE users to apply this access control for.
+
+author:
+    - Musee Ullah (@lae)
+'''
+
+EXAMPLES = '''
+- name: Allow Admins group Administrator access to /
+  proxmox_acl:
+    path: /
+    roles: [ "Administrator" ]
+    groups: [ "Admins" ]
+- name: Allow pveapi@pve and test_users group PVEAdmin access to /pools/testpool
+  proxmox_acl:
+    path: /pools/testpool
+    roles: [ "PVEAdmin" ]
+    users:
+      - pveapi@pve
+    groups:
+      - test_users
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pvesh import ProxmoxShellError
+import ansible.module_utils.pvesh as pvesh
+
+class ProxmoxACL(object):
+    def __init__(self, module):
+        self.module = module
+        self.path = module.params['path']
+        self.state = module.params['state']
+        self.roles = module.params['roles']
+        self.groups = module.params['groups']
+        self.users = module.params['users']
+
+        try:
+            self.existing_acl = pvesh.get("access/acl")
+        except ProxmoxShellError as e:
+            self.module.fail_json(msg=e.message, status_code=e.status_code)
+
+        self.parse_acls()
+
+    def parse_acls(self):
+        constituents = []
+
+        if self.users is not None:
+            [constituents.append(["user", user]) for user in self.users]
+
+        if self.groups is not None:
+            [constituents.append(["group", group]) for group in self.groups]
+
+        self.acls = []
+        for role in self.roles:
+            for constituent in constituents:
+                self.acls.append({
+                    "path": self.path,
+                    "propagate": "1", # possibly make this configurable in the module later
+                    "roleid": role,
+                    "type": constituent[0],
+                    "ugid": constituent[1]
+                })
+
+    def exists(self):
+        for acl in self.acls:
+            if acl not in self.existing_acl:
+                return False
+
+        return True
+
+    def prepare_acl_args(self):
+        args = {}
+        args['path'] = self.path
+        args['roles'] = ','.join(self.roles)
+
+        if self.groups is not None:
+            args['groups'] = ','.join(self.groups)
+
+        if self.users is not None:
+            args['users'] = ','.join(self.users)
+
+        return args
+
+    def set_acl(self, delete=0):
+        acls = self.prepare_acl_args()
+
+        try:
+            pvesh.set("access/acl", delete=delete, **acls)
+            return None
+        except ProxmoxShellError as e:
+            return e.message
+
+def main():
+    # Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html
+    module = AnsibleModule(
+        argument_spec = dict(
+            path=dict(type='str', required=True, aliases=['resource']),
+            roles=dict(type='list', required=True),
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            groups=dict(default=None, type='list'),
+            users=dict(default=None, type='list'),
+        ),
+        required_one_of=[["groups", "users"]],
+        supports_check_mode=True
+    )
+
+    acl = ProxmoxACL(module)
+
+    error = None
+    result = {}
+    result['state'] = acl.state
+    result['changed'] = False
+
+    if acl.state == 'absent':
+        if acl.exists():
+            result['changed'] = True
+            if module.check_mode:
+                module.exit_json(**result)
+
+            error = acl.set_acl(delete=1)
+    elif acl.state == 'present':
+        if not acl.exists():
+            result['changed'] = True
+            if module.check_mode:
+                module.exit_json(**result)
+
+            error = acl.set_acl()
+
+    if error is not None:
+        module.fail_json(path=acl.path, msg=error)
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/pvesh.py
+++ b/module_utils/pvesh.py
@@ -13,15 +13,15 @@ class ProxmoxShellError(Exception):
         if "data" in response:
             self.data = response["data"]
 
-def run_command(handler, path, **params):
+def run_command(handler, resource, **params):
     # pvesh strips these before handling, so might as well
-    path = path.strip('/')
+    resource = resource.strip('/')
     # pvesh only has lowercase handlers
     handler = handler.lower()
     command = [
         "/usr/bin/pvesh",
         handler,
-        path]
+        resource]
     for parameter, value in params.iteritems():
         command += ["-{}".format(parameter), "{}".format(value)]
 
@@ -47,7 +47,7 @@ def run_command(handler, path, **params):
         if stderr[0] == "400 Parameter verification failed.":
             return {u"status": 400, u"message": "\n".join(stderr[1:-1])}
 
-        if stderr[0] == "no '{}' handler for '{}'".format(handler, path):
+        if stderr[0] == "no '{}' handler for '{}'".format(handler, resource):
             return {u"status": 405, u"message": stderr[0]}
 
         if handler == "get":
@@ -65,8 +65,8 @@ def run_command(handler, path, **params):
 
     return {u"status": 500, u"message": u"Unexpected result occurred but no error message was provided by pvesh."}
 
-def get(path):
-    response = run_command("get", path)
+def get(resource):
+    response = run_command("get", resource)
 
     if response["status"] == 404:
         return None
@@ -76,20 +76,20 @@ def get(path):
 
     raise ProxmoxShellError(response)
 
-def delete(path):
-    response = run_command("delete", path)
+def delete(resource):
+    response = run_command("delete", resource)
 
     if response["status"] != 200:
         raise ProxmoxShellError(response)
 
-def create(path, **params):
-    response = run_command("create", path, **params)
+def create(resource, **params):
+    response = run_command("create", resource, **params)
 
     if response["status"] != 200:
         raise ProxmoxShellError(response)
 
-def set(path, **params):
-    response = run_command("set", path, **params)
+def set(resource, **params):
+    response = run_command("set", resource, **params)
 
     if response["status"] != 200:
         raise ProxmoxShellError(response)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,6 +112,12 @@
   args: "{{ item }}"
   with_items: "{{ pve_users }}"
   when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
+  
+- name: Configure Proxmox ACLs
+  proxmox_acl:
+  args: "{{ item }}"
+  with_items: "{{ pve_acls }}"
+  when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
 
 - include: ssl_config.yml
   when:

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -36,6 +36,16 @@ pve_users:
     email: tempuser@pve.example
     firstname: Test
     lastname: User
+pve_acls: # This should generate 3 different ACLs (note that this is count should be modified in tests/test.yml if this var is changed)
+  - path: /
+    roles: [ "Administrator" ]
+    groups: [ "Admins" ]
+  - path: /pools/testpool
+    roles: [ "PVEAdmin" ]
+    users:
+      - pveapi@pve
+    groups:
+      - test_users
 
 ssl_directory: /home/travis/ssl/
 ssl_ca_key_path: "{{ ssl_directory }}/test-ca.key"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,19 +4,23 @@
     - name: Ensure Proxmox Web UI returns a successful HTTP response
       uri:
         url: "https://{{ inventory_hostname }}:8006"
+
     - name: Query PVE cluster status
       shell: "pvesh get /cluster/status"
       register: __pve_cluster
       changed_when: False
+
     - name: Check that this node is within the cluster and it is in quorum
       assert:
         that: "(__pve_cluster.stdout | from_json | json_query(query)) == 1"
       vars:
         query: "([?type=='cluster'].quorate)[0]"
+
     - name: Query PVE groups
       shell: "pvesh get /access/groups"
       register: __pve_groups
       changed_when: False
+
     - name: Check that PVE groups exist
       assert:
         that: "(__pve_groups.stdout | from_json | json_query(query)) == 1"
@@ -24,10 +28,12 @@
         query: "length([?groupid=='{{ item.name }}'])"
       run_once: True
       with_items: "{{ pve_groups }}"
+
     - name: Query PVE users
       shell: "pvesh get /access/users"
       register: __pve_users
       changed_when: False
+
     - name: Check that PVE users exist
       assert:
         that: "(__pve_users.stdout | from_json | json_query(query)) == 1"
@@ -35,6 +41,19 @@
         query: "length([?userid=='{{ item.name }}'])"
       run_once: True
       with_items: "{{ pve_users }}"
+
+    - name: Query PVE ACLs
+      shell: "pvesh get /access/acl"
+      register: __pve_acl
+      changed_when: False
+
+    - name: Check that PVE ACLs exist
+      assert:
+        that: "(__pve_acl.stdout | from_json | json_query(query)) == 3"
+      vars:
+        query: "length([])"
+      run_once: True
+
     - block:
       - name: pvedaemon service status
         shell: "journalctl --no-pager -xu pvedaemon.service"


### PR DESCRIPTION
This adds a `proxmox_acl` module, with similar characteristics to #18. They're defined through `pve_acls`.