### PR TITLE
ZFS and extra package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,12 +355,15 @@ Role Variables
 pve_group: proxmox # host group that contains the Proxmox hosts to be clustered together
 pve_fetch_directory: fetch/ # local directory used to download root public keys from each host to
 pve_repository_line: "deb http://download.proxmox.com/debian/pve stretch pve-no-subscription" # apt-repository configuration - change to enterprise if needed (although TODO further configuration may be needed)
+pve_extra_packages: [] # Any extra packages you may want to install, e.g. ngrep
 pve_check_for_kernel_update: true # Runs a script on the host to check kernel versions
 pve_reboot_on_kernel_update: false # If set to true, will automatically reboot the machine on kernel updates
 pve_remove_old_kernels: true # Currently removes kernel from main Debian repository
 pve_watchdog: none # Set this to "ipmi" if you want to configure a hardware watchdog. Proxmox uses a software watchdog (nmi_watchdog) by default.
 pve_watchdog_ipmi_action: power_cycle # Can be one of "reset", "power_cycle", and "power_off".
 pve_watchdog_ipmi_timeout: 10 # Number of seconds the watchdog should wait
+pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS packages - if enabled after PVE is already installed, a reboot is suggested.
+pve_zfs_zed_email: "" # Should be set to an email to receive ZFS notifications
 # pve_ssl_private_key: "" # Should be set to the contents of the private key to use for HTTPS
 # pve_ssl_certificate: "" # Should be set to the contents of the certificate to use for HTTPS
 pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
@@ -388,12 +391,13 @@ pve_cluster_bindnet0_addr: "{{ pve_cluster_ring0_addr }}"
 Dependencies
 ------------
 
-This role does not install NTP, so you should configure NTP yourself, with the `geerlingguy.ntp` role as in the examples.
+This role does not install NTP, so you should configure NTP yourself, e.g. with
+the `geerlingguy.ntp` role as shown in the example playbook.
 
-When cluster is enabled, this role makes use of the `json_query` filter, which
-requires that the `jmespath` library be installed on your control host. You can
-either `pip install jmespath` or install it via your distribution's package
-manager, e.g. `apt-get install python-jmespath`.
+When clustering is enabled, this role makes use of the `json_query` filter,
+which requires that the `jmespath` library be installed on your control host.
+You can either `pip install jmespath` or install it via your distribution's
+package manager, e.g. `apt-get install python-jmespath`.
 
 User and ACL Management
 ---------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,15 @@
 pve_group: proxmox
 pve_fetch_directory: fetch
 pve_repository_line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
+pve_extra_packages: []
 pve_check_for_kernel_update: true
 pve_reboot_on_kernel_update: false
 pve_remove_old_kernels: true
 pve_watchdog: none
 pve_watchdog_ipmi_action: power_cycle
 pve_watchdog_ipmi_timeout: 10
+pve_zfs_enabled: no
+# pve_zfs_zed_email: "email address for zfs events"
 # pve_ssl_private_key: "contents of private key"
 # pve_ssl_certificate: "contents of certificate"
 pve_cluster_enabled: no

--- a/tasks/identify_needed_packages.yml
+++ b/tasks/identify_needed_packages.yml
@@ -1,0 +1,23 @@
+---
+- name: Stage packages needed for base PVE installation
+  set_fact:
+    __pve_install_packages:
+      - proxmox-ve
+      - postfix
+      - open-iscsi
+      - ksm-control-daemon
+      - systemd-sysv
+
+- name: Stage patch package if we need to patch the subscription message
+  set_fact:
+    __pve_install_packages: "{{ __pve_install_packages | union(['patch']) }}"
+  when: "'pve-no-subscription' in pve_repository_line"
+
+- name: Stage ZFS packages if ZFS is enabled
+  set_fact:
+    __pve_install_packages: "{{ __pve_install_packages | union(['zfsutils-linux', 'zfs-initramfs', 'zfs-zed']) }}"
+  when: pve_zfs_enabled
+
+- name: Stage any extra packages the user has specified
+  set_fact:
+    __pve_install_packages: "{{ __pve_install_packages | union(pve_extra_packages) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,11 @@
     id: "{{ pve_release_key_id }}"
     state: present
 
+- name: Remove os-prober package
+  apt:
+    name: os-prober
+    state: absent
+
 - name: Add Proxmox repository
   apt_repository:
     repo: "{{ pve_repository_line }}"
@@ -61,11 +66,6 @@
     update_cache: yes
     cache_valid_time: 3600
     upgrade: dist
-
-- name: Remove os-prober package
-  apt:
-    name: os-prober
-    state: absent
 
 - name: Install Proxmox VE and related packages
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,21 +67,15 @@
     cache_valid_time: 3600
     upgrade: dist
 
+- include: identify_needed_packages.yml
+
 - name: Install Proxmox VE and related packages
   apt:
     name: "{{ item }}"
     state: latest
-  with_items:
-    - proxmox-ve
-    - postfix
-    - open-iscsi
-    - ksm-control-daemon
-    - systemd-sysv
-    - patch
-    - python-pip
+  with_items: "{{ __pve_install_packages }}"
 
 - block:
-
   - name: Remove automatically installed PVE Enterprise repo configuration
     apt_repository:
       repo: "{{ item }}"
@@ -98,13 +92,19 @@
       src: 00_remove_checked_command.patch
       dest: /usr/share/pve-manager/js/pvemanagerlib.js
       backup: yes
-
   when: "'pve-no-subscription' in pve_repository_line"
 
-- include: kernel_updates.yml
+- name: Configure email address for ZFS event daemon notifications
+  lineinfile:
+    dest: /etc/zfs/zed.d/zed.rc
+    line: 'ZED_EMAIL_ADDR="{{ pve_zfs_zed_email }}"'
+    regexp: '^#?ZED_EMAIL_ADDR='
+  when: pve_zfs_zed_email is defined
 
 - include: ipmi_watchdog.yml
   when: pve_watchdog == 'ipmi'
+
+- include: kernel_updates.yml
 
 - include: pve_cluster_config.yml
   when: pve_cluster_enabled

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -1,8 +1,12 @@
 ---
 ansible_ssh_user: root
 
+pve_extra_packages:
+  - sl
 pve_check_for_kernel_update: false
 pve_watchdog: ipmi
+pve_zfs_enabled: yes
+pve_zfs_zed_email: root@localhost
 pve_ssl_private_key: "{{ lookup('file', ssl_host_key_path) }}"
 pve_ssl_certificate: "{{ lookup('file', ssl_host_cert_path) }}"
 pve_cluster_enabled: yes


### PR DESCRIPTION
This introduces a variable to set to install ZFS packages and any extra packages, as well as reorganizes some tasks. It allows an email to be configured to receive events from the ZFS module. It also removes installation of `python-pip` (as this role does not install `proxmoxer` anymore, and it adds to the installation time).