### PR TITLE
Limit root login between PVE cluster hosts to key authentication

### DIFF
--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -44,7 +44,7 @@
     content: |
       {% for host in groups[pve_group] %}
       Match Address {{ hostvars[host].ansible_default_ipv4.address }}
-      PermitRootLogin yes
+      PermitRootLogin {{ pve_sshd_prohibit_password }}
       {% endfor %}
     validate: "/usr/sbin/sshd -t -f %s"
   notify:

--- a/vars/debian-jessie.yml
+++ b/vars/debian-jessie.yml
@@ -2,3 +2,4 @@
 pve_release_key: proxmox-ve-release-4.x.asc
 pve_release_key_id: C23AC7F49887F95A
 pve_ssh_ciphers: "blowfish-cbc,aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128,aes128-cbc,3des-cbc"
+pve_sshd_prohibit_password: without-password

--- a/vars/debian-stretch.yml
+++ b/vars/debian-stretch.yml
@@ -2,3 +2,4 @@
 pve_release_key: proxmox-ve-release-5.x.asc
 pve_release_key_id: 0D9A1950E2EF0603
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_sshd_prohibit_password: prohibit-password


### PR DESCRIPTION
To my knowledge, there's no need to allow password authentication.

Btw, thanks for the great role. I'm just starting to use it :)