### PR TITLE
Only run 'apt dist-upgrade' after adding the proxmox repository

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,12 +60,14 @@
     repo: "{{ pve_repository_line }}"
     filename: proxmox
     state: present
+  register: __pve_apt_add_repo
 
 - name: Run dist-upgrade
   apt:
     update_cache: yes
     cache_valid_time: 3600
     upgrade: "{{ pve_upgrade }}"
+  when: __pve_apt_add_repo.changed
 
 - include: identify_needed_packages.yml
 


### PR DESCRIPTION
I don't see a reason to run 'apt dist-upgrade' every time the role is
executed. It's better to do this only directly after the proxmox
repository got added/changed.