### PR TITLE
Let's Encrypt SSL certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ playbook, e.g. `files/pve01/lab-node01.key`. You could possibly just use host
 variables instead of files, if you prefer.
 
 `pve_ssl_letsencrypt` allows to obtain a Let's Encrypt SSL certificate for
-pvecluster. The Ansible role [systemli-letsencrypt](https://github.com/systemli/ansible-role-letsencrypt)
+pvecluster. The Ansible role [systemli.letsencrypt](https://galaxy.ansible.com/systemli/letsencrypt/)
 needs to be installed first in order to use this function.
 
 `pve_cluster_enabled` enables the role to perform all cluster management tasks.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS pack
 # pve_zfs_zed_email: "" # Should be set to an email to receive ZFS notifications
 # pve_ssl_private_key: "" # Should be set to the contents of the private key to use for HTTPS
 # pve_ssl_certificate: "" # Should be set to the contents of the certificate to use for HTTPS
-pve_ssl_letsencrypt: no # Specifies whether or not to obtain a SSL certificate using Let's Encrypt
+pve_ssl_letsencrypt: false # Specifies whether or not to obtain a SSL certificate using Let's Encrypt
 pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
 pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 ```

--- a/README.md
+++ b/README.md
@@ -183,9 +183,14 @@ host into the appropriate configuration files.
 `pve_watchdog` here enables IPMI watchdog support and configures PVE's HA
 manager to use it. Leave this undefined if you don't want to configure it.
 
-`pve_ssl_private_key` and `pve_ssl_certificate` here uses a file lookup to read
-the contents of a file in the playbook, e.g. `files/pve01/lab-node01.key`. You
-could possibly just use host variables instead of files, if you prefer.
+`pve_ssl_private_key` and `pve_ssl_certificate` point to the SSL certificates for
+pvecluster. Here, a file lookup is used to read the contents of a file in the
+playbook, e.g. `files/pve01/lab-node01.key`. You could possibly just use host
+variables instead of files, if you prefer.
+
+`pve_ssl_letsencrypt` allows to obtain a Let's Encrypt SSL certificate for
+pvecluster. The Ansible role [systemli-letsencrypt](https://github.com/systemli/ansible-role-letsencrypt)
+needs to be installed first in order to use this function.
 
 `pve_cluster_enabled` enables the role to perform all cluster management tasks.
 This includes creating a cluster if it doesn't exist, or adding nodes to the
@@ -369,6 +374,7 @@ pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS pack
 # pve_zfs_zed_email: "" # Should be set to an email to receive ZFS notifications
 # pve_ssl_private_key: "" # Should be set to the contents of the private key to use for HTTPS
 # pve_ssl_certificate: "" # Should be set to the contents of the certificate to use for HTTPS
+pve_ssl_letsencrypt: no # Specifies whether or not to obtain a SSL certificate using Let's Encrypt
 pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
 pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ pve_cluster_ring0_addr: "{{ ansible_default_ipv4.address }}"
 pve_cluster_bindnet0_addr: "{{ pve_cluster_ring0_addr }}"
 # pve_cluster_ring1_addr: "another interface's IP address or hostname"
 # pve_cluster_bindnet1_addr: "{{ pve_cluster_ring1_addr }}"
+pve_ssl_letsencrypt: false
 pve_groups: []
 pve_users: []
 pve_acls: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,3 +134,6 @@
   when:
     - pve_ssl_private_key is defined
     - pve_ssl_certificate is defined
+
+- include: ssl_letsencrypt.yml
+  when: pve_ssl_letsencrypt

--- a/tasks/ssl_letsencrypt.yml
+++ b/tasks/ssl_letsencrypt.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Install Proxmox Let's Encrypt post-hook script
+  template:
+    src: pve-letsencrypt-post-hook.sh.j2
+    dest: /usr/local/bin/pve-letsencrypt-post-hook.sh
+    mode: 0755
+
+- name: Request Let's Encrypt certificate for {{ ansible_fqdn }}
+  include_role:
+    name: letsencrypt
+  vars:
+    - letsencrypt_cert:
+        name: "{{ ansible_fqdn }}"
+        domains:
+          - "{{ ansible_fqdn }}"
+        challenge: http
+        http_auth: standalone
+        post_hook: /usr/local/bin/pve-letsencrypt-post-hook.sh

--- a/tasks/ssl_letsencrypt.yml
+++ b/tasks/ssl_letsencrypt.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install Proxmox Let's Encrypt post-hook script
   template:
     src: pve-letsencrypt-post-hook.sh.j2

--- a/tasks/ssl_letsencrypt.yml
+++ b/tasks/ssl_letsencrypt.yml
@@ -8,7 +8,7 @@
 
 - name: Request Let's Encrypt certificate for {{ ansible_fqdn }}
   include_role:
-    name: letsencrypt
+    name: systemli.letsencrypt
   vars:
     - letsencrypt_cert:
         name: "{{ ansible_fqdn }}"

--- a/templates/pve-letsencrypt-post-hook.sh.j2
+++ b/templates/pve-letsencrypt-post-hook.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem   /etc/pve/local/pveproxy-ssl.key
+cp /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem /etc/pve/local/pveproxy-ssl.pem
+service pveproxy restart


### PR DESCRIPTION
This PR adds new tasks to obtain and install Let's Encrypt SSL certificates for pveproxy using the external role [systemli.letsencrypt](https://galaxy.ansible.com/systemli/letsencrypt/).