### PR TITLE
Fix deprecation warnings for Ansible 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Finally, let's write our playbook. `site.yml` will look something like this:
       - name: Wait for server to come back online
         wait_for_connection:
           delay: 15
-      when: __configure_interfaces | changed
+      when: __configure_interfaces is changed
 
 - hosts: pve
   become: True

--- a/tasks/disable_nmi_watchdog.yml
+++ b/tasks/disable_nmi_watchdog.yml
@@ -12,7 +12,6 @@
   register: __pve_rmmod_softdog
 
 - block:
-
   - name: Stop watchdog-mux
     service:
       name: watchdog-mux
@@ -25,7 +24,7 @@
       name: softdog
       state: absent
 
-  when: __pve_rmmod_softdog|failed
+  when: __pve_rmmod_softdog is failed
 
 - name: Disable nmi_watchdog via GRUB config
   lineinfile:
@@ -38,5 +37,5 @@
   command: update-grub
   register: __pve_grub_update
   failed_when: ('error' in __pve_grub_update.stderr)
-  when: __pve_grub|changed
+  when: __pve_grub is changed
   tags: skiponlxc

--- a/tasks/ipmi_watchdog.yml
+++ b/tasks/ipmi_watchdog.yml
@@ -1,5 +1,5 @@
 ---
-- include: disable_nmi_watchdog.yml
+- import_tasks: disable_nmi_watchdog.yml
 
 - name: Load ipmi_watchdog module
   modprobe:

--- a/tasks/kernel_module_cleanup.yml
+++ b/tasks/kernel_module_cleanup.yml
@@ -26,7 +26,7 @@
     command: update-grub
     register: __pve_grub_update
     failed_when: ('error' in __pve_grub_update.stderr)
-    when: __pve_grub|changed
+    when: __pve_grub is changed
     tags: skiponlxc
 
   - name: Remove ipmi_watchdog modprobe configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     msg: "This host does not appear to be in the group {{ pve_group }}, did you specify the pve_group host variable correctly?"
   when: pve_cluster_enabled
 
-- include: ssh_cluster_config.yml
+- import_tasks: ssh_cluster_config.yml
 
 - name: Run handlers if needed (sshd reload)
   meta: flush_handlers
@@ -76,7 +76,7 @@
     upgrade: yes
   when: pve_run_system_upgrades
 
-- include: identify_needed_packages.yml
+- import_tasks: identify_needed_packages.yml
 
 - name: Install Proxmox VE and related packages
   apt:
@@ -108,41 +108,49 @@
   when:
     - "'pve-no-subscription' in pve_repository_line"
 
-- include: kernel_updates.yml
+- import_tasks: kernel_updates.yml
 
-- include: ipmi_watchdog.yml
+- import_tasks: ipmi_watchdog.yml
   when: pve_watchdog == 'ipmi'
 
-- include: zfs.yml
+- import_tasks: zfs.yml
   when: pve_zfs_enabled
 
-- include: kernel_module_cleanup.yml
+- import_tasks: kernel_module_cleanup.yml
 
-- include: pve_cluster_config.yml
+- import_tasks: pve_cluster_config.yml
   when: pve_cluster_enabled
 
 - name: Configure Proxmox groups
   proxmox_group:
-  args: "{{ item }}"
+    name: "{{ item.name }}"
+    comment: "{{ item.comment | default(omit) }}"
   with_items: "{{ pve_groups }}"
   when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
 
 - name: Configure Proxmox user accounts
   proxmox_user:
-  args: "{{ item }}"
+    name: "{{ item.name }}"
+    email: "{{ item.email | default(omit) }}"
+    firstname: "{{ item.firstname | default(omit) }}"
+    lastname: "{{ item.lastname | default(omit) }}"
+    groups: "{{ item.groups | default([]) }}"
   with_items: "{{ pve_users }}"
   when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
 
 - name: Configure Proxmox ACLs
   proxmox_acl:
-  args: "{{ item }}"
+    path: "{{ item.path }}"
+    roles: "{{ item.roles }}"
+    groups: "{{ item.groups | default([]) }}"
+    users: "{{ item.users | default([]) }}"
   with_items: "{{ pve_acls }}"
   when: "not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])"
 
-- include: ssl_config.yml
+- import_tasks: ssl_config.yml
   when:
     - pve_ssl_private_key is defined
     - pve_ssl_certificate is defined
 
-- include: ssl_letsencrypt.yml
+- import_tasks: ssl_letsencrypt.yml
   when: pve_ssl_letsencrypt


### PR DESCRIPTION
Switch all includes to import_tasks or include_tasks
Update filter tests
Replace 'unsafe' args for ACL management