### PR TITLE
`with_items` is deprecated for apt module from the 2.7 version

### DIFF
--- a/tasks/kernel_updates.yml
+++ b/tasks/kernel_updates.yml
@@ -24,11 +24,8 @@
 
 - name: Remove old Debian/PVE kernels
   apt:
-    name: "{{ item }}"
+    name: "{{ ['linux-image-amd64'] + __pve_kernel.old_packages }}"
     state: absent
     purge: yes
-  with_items: 
-    - linux-image-amd64
-    - "{{ __pve_kernel.old_packages }}"
   when:
     - pve_remove_old_kernels

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,9 +80,8 @@
 
 - name: Install Proxmox VE and related packages
   apt:
-    name: "{{ item }}"
+    name: "{{ __pve_install_packages }}"
     state: latest
-  with_items: "{{ __pve_install_packages }}"
 
 - block:
   - name: Remove automatically installed PVE Enterprise repo configuration


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying 
`name: {{ item }}`, please use `name: [u'linux-image-amd64', u'{{ __pve_kernel.old_packages }}']` and remove the loop. This feature will be removed in version 2.11. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.