### PR TITLE
[WIP] Use ring0 instead of default ipv4 for hosts file and sshd configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     marker: "# {mark} ANSIBLE MANAGED: Proxmox Cluster Hosts"
     content: |
       {% for host in groups[pve_group] %}
-      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}{% if ansible_fqdn == hostvars[host].ansible_fqdn %} pvelocalhost{% endif %}
+      {{ hostvars[host].pve_cluster_ring0_addr | default(hostvars[host].ansible_default_ipv4.address) }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}{% if ansible_fqdn == hostvars[host].ansible_fqdn %} pvelocalhost{% endif %}
 
       {% endfor %}
 
@@ -42,7 +42,7 @@
     # above, then we match against different IPs (e.g. NOT 10.0.3.17) that have
     # the hostname/fqdn we inserted a record for previously, taking care also to
     # detect word boundaries (\b wasn't working for some reason)
-    regexp: '^(?!{{ hostvars[item].ansible_default_ipv4.address | regex_escape() }} {{ hostvars[item].ansible_fqdn | regex_escape() }} {{ hostvars[item].ansible_hostname | regex_escape() }}( pvelocalhost)?)(?!{{ hostvars[item].ansible_default_ipv4.address | regex_escape() }})[\w:.]+(\s+.*)?\s({{ hostvars[item].ansible_fqdn | regex_escape() }}|{{ hostvars[item].ansible_hostname | regex_escape() }}{% if ansible_fqdn == hostvars[item].ansible_fqdn %}|pvelocalhost{% endif %})(\s+.*|\s*)$'
+    regexp: '^(?!{{ hostvars[item].pve_cluster_ring0_addr | default(hostvars[item].ansible_default_ipv4.address) | regex_escape() }} {{ hostvars[item].ansible_fqdn | regex_escape() }} {{ hostvars[item].ansible_hostname | regex_escape() }}( pvelocalhost)?)(?!{{ hostvars[item].pve_cluster_ring0_addr | regex_escape() }})[\w:.]+(\s+.*)?\s({{ hostvars[item].ansible_fqdn | regex_escape() }}|{{ hostvars[item].ansible_hostname | regex_escape() }}{% if ansible_fqdn == hostvars[item].ansible_fqdn %}|pvelocalhost{% endif %})(\s+.*|\s*)$'
     state: absent
     backup: yes
   with_items: "{{ groups[pve_group] }}"

--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -43,7 +43,7 @@
     marker: "# {mark}: Allow root logins from PVE hosts (managed by ansible)."
     content: |
       {% for host in groups[pve_group] %}
-      Match Address {{ hostvars[host].ansible_default_ipv4.address }}
+      Match Address {{ hostvars[host].pve_cluster_ring0_addr | default(hostvars[host].ansible_default_ipv4.address) }}
       PermitRootLogin prohibit-password
       {% endfor %}
     validate: "/usr/sbin/sshd -t -f %s"


### PR DESCRIPTION
Hi,
When setting a pve_cluster_ring0_addr, the role still uses the ansible_default_ipv4.address in the hosts file for the nodes, and in the permissive sshd configuration. By default, pve_cluster_ring0_addr is set to ansible_default_ipv4.address so this won't change.
What will change will be, if you set the pve_cluster_ring0_addr:
 - the hosts file will use it
 - the sshd config file will use it

It might be better to give the user the choice, but in my opinion, that's how it should behave, if I use a ring0 addr, I probably am interested in using that address for inter node communication all the way. Also, I didn't see an obvious path to set a choice here, due to the variable priorities in ansible, but it's possible.

Thanks for this torough role by the way, it proved really useful.
Regards,
Gilou
