### PR TITLE
Don't install postfix

### DIFF
--- a/tasks/identify_needed_packages.yml
+++ b/tasks/identify_needed_packages.yml
@@ -3,7 +3,6 @@
   set_fact:
     _pve_install_packages:
       - proxmox-ve
-      - postfix
       - open-iscsi
       - ksm-control-daemon
       - systemd-sysv


### PR DESCRIPTION
Hard-coding an MTA to install prevents users of this role from using an
alternative MTA of their choice.

While an MTA is required to use Proxmox VE there is already a dependency
on the mail-transport-agent meta-package in the Proxmox packages which
ensures that this requirement is satisfied. Leave the choice of which MTA
to use to the user and don't hard-code it in this role.