### PR TITLE
Don't modprobe in Travis CI tests

### DIFF
--- a/tasks/disable_nmi_watchdog.yml
+++ b/tasks/disable_nmi_watchdog.yml
@@ -3,6 +3,7 @@
   modprobe:
     name: nmi_watchdog
     state: absent
+  tags: skiponlxc
 
 - name: Attempt to unload softdog live
   modprobe:
@@ -10,6 +11,7 @@
     state: absent
   ignore_errors: true
   register: _pve_rmmod_softdog
+  tags: skiponlxc
 
 - block:
   - name: Stop watchdog-mux
@@ -25,6 +27,7 @@
       state: absent
 
   when: _pve_rmmod_softdog is failed
+  tags: skiponlxc
 
 - name: Disable nmi_watchdog via GRUB config
   lineinfile:

--- a/tasks/kernel_module_cleanup.yml
+++ b/tasks/kernel_module_cleanup.yml
@@ -37,6 +37,7 @@
   - name: Load softdog
     modprobe:
       name: softdog
+    tags: skiponlxc
 
   - name: Set PVE HA Manager watchdog configuration back to default
     copy:


### PR DESCRIPTION
A change in the modprobe module in Ansible 2.8 made the module fail even
if the state is already correct. Because of this the task "Unload
nmi_watchdog" failed in tests.

Loading and unloading modules does not work when running tests on Travis
CI in an LXC container. This adds the "skiponlxc" tag to all invocations of
the modprobe Ansible module.