### PR TITLE
Add different ceph repository for proxmox 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS pack
 # pve_zfs_options: "" # modprobe parameters to pass to zfs module on boot/modprobe
 # pve_zfs_zed_email: "" # Should be set to an email to receive ZFS notifications
 pve_ceph_enabled: false # Specifies wheter or not to install and configure Ceph packages. See below for an example configuration.
+pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-nautilus buster main" # apt-repository configuration. Will be automatically set for 5.x and 6.x (Further information: https://pve.proxmox.com/wiki/Package_Repositories)
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}" # Ceph cluster network
 pve_ceph_mon_group: "{{ pve_group }}" # Host group containing all Ceph monitor hosts
 pve_ceph_mds_group: "{{ pve_group }}" # Host group containing all Ceph metadata server hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ pve_zfs_enabled: no
 # pve_zfs_options: "parameters to pass to zfs module"
 # pve_zfs_zed_email: "email address for zfs events"
 pve_ceph_enabled: false
+pve_ceph_repository_line: "{{ pve_ceph_repo }}"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}"
 pve_ceph_mon_group: "{{ pve_group }}"
 pve_ceph_mds_group: "{{ pve_group }}"

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -1,7 +1,7 @@
 # This is an Ansible version of what "pveceph install" actually does
 - name: Configure Ceph package source
   apt_repository:
-    repo: 'deb http://download.proxmox.com/debian/ceph-luminous stretch main'
+    repo: '{{ pve_ceph_repository_line }}'
     filename: ceph.list
     state: present
 
@@ -24,11 +24,15 @@
     group: root
     mode: preserve
   notify: 'restart ceph'
+  when:
+    - "ansible_distribution_release == 'stretch'"
 
 - name: Enable Ceph
   systemd:
     name: ceph.service
     enabled: true
+  when:
+  - "ansible_distribution_release == 'stretch'"
 
 - name: Create initial Ceph config
   command: 'pveceph init --network {{ pve_ceph_network }}'

--- a/vars/debian-buster.yml
+++ b/vars/debian-buster.yml
@@ -2,3 +2,4 @@
 pve_release_key: proxmox-ve-release-6.x.asc
 pve_release_key_id: 7BF2812E8A6E88E0
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_ceph_repo: deb http://download.proxmox.com/debian/ceph-nautilus buster main

--- a/vars/debian-stretch.yml
+++ b/vars/debian-stretch.yml
@@ -2,3 +2,4 @@
 pve_release_key: proxmox-ve-release-5.x.asc
 pve_release_key_id: 0D9A1950E2EF0603
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_ceph_repo: "deb http://download.proxmox.com/debian/ceph-luminous stretch main"


### PR DESCRIPTION
Current implementation of ceph is not working with proxmox 6.x because the repository is different (nautilus instead of luminous). Another problem is with the ceph service, the used template under  /usr/share/doc/pve-manager/examples/ceph.service does not exist in proxmox 6.x. Maybe there has to be another fix (I do not know the purpose for this service, proxmox is starting the services well).