### PR TITLE
Allow SSH port for cluster hosts to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 lae.proxmox
 ===========
 
-Installs and configures a Proxmox 5.x cluster with the following features:
+Installs and configures a Proxmox 5.x/6.x cluster with the following features:
 
 - Ensures all hosts can connect to one another as root
 - Ability to create/manage groups, users, access control lists and storage
@@ -177,6 +177,7 @@ pve_storages:
     content: [ "images", "iso", "backup" ]
     path: /plop
     maxfiles: 4
+pve_ssh_port: 22
 
 interfaces_template: "interfaces-{{ pve_group }}.j2"
 ```
@@ -215,6 +216,10 @@ of the `ops` group. Read the **User and ACL Management** section for more info.
 `pve_storages` allows to create different types of storage and configure them.
 The backend needs to be supported by [Proxmox](https://pve.proxmox.com/pve-docs/chapter-pvesm.html).
 Read the **Storage Management** section for more info.
+
+'pve_ssh_port' allows you to change the SSH service port. If your SSH is listing
+on a different port then 22, please set this variable. If a new node is joining
+the cluster, the PVE cluster needs to communicate once via SSH.
 
 `interfaces_template` is set to the path of a template we'll use for configuring
 the network on these Debian machines. This is only necessary if you want to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,3 +43,4 @@ pve_groups: []
 pve_users: []
 pve_acls: []
 pve_storages: []
+pve_ssh_port: 22

--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -35,6 +35,7 @@
       {% for host in groups[pve_group] %}
       Host {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }} {{ hostvars[host].ansible_default_ipv4.address }}
           IdentityFile /root/.ssh/id_rsa
+          Port {{ pve_ssh_port }}
       {% endfor %}
 
 - name: Allow root logins from PVE cluster hosts


### PR DESCRIPTION
If the SSH port on the hosts is not the default port, then joining a Cluster with -use-ssh will never work. With the new variable pve_ssh_port it is possible to set the specific port. It will be written to /etc/ssh/ssh_config which is already changed by hostkey assignment and it makes sense to change the default port there too.