### PR TITLE
Optionally leave SSH config alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,15 @@ of the `ops` group. Read the **User and ACL Management** section for more info.
 The backend needs to be supported by [Proxmox](https://pve.proxmox.com/pve-docs/chapter-pvesm.html).
 Read the **Storage Management** section for more info.
 
-`pve_ssh_port` allows you to change the SSH service port. If your SSH is listing
-on a different port then 22, please set this variable. If a new node is joining
-the cluster, the PVE cluster needs to communicate once via SSH.
+`pve_ssh_port` allows you to change the SSH port. If your SSH is listening on
+a port other than the default 22, please set this variable. If a new node is
+joining the cluster, the PVE cluster needs to communicate once via SSH.
+
+`pve_manage_ssh` (default true) allows you to disable any changes this module
+would make to your SSH server config. This is useful if you use another role
+to manage your SSH server. Note that setting this to false is not officially
+supported, you're on your own to replicate the changes normally made in
+ssh_cluster_config.yml.
 
 `interfaces_template` is set to the path of a template we'll use for configuring
 the network on these Debian machines. This is only necessary if you want to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,4 @@ pve_users: []
 pve_acls: []
 pve_storages: []
 pve_ssh_port: 22
+pve_manage_ssh: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,8 @@
   when: "pve_cluster_enabled | bool"
 
 - import_tasks: ssh_cluster_config.yml
+  when:
+    - "pve_manage_ssh | bool and pve_cluster_enabled | bool"
 
 - name: Run handlers if needed (sshd reload)
   meta: flush_handlers


### PR DESCRIPTION
I manage my SSH configuration with an [sshd role](https://galaxy.ansible.com/willshersystems/sshd). My particular use case doesn't yet use clustering, so the management of SSH in this module isn't needed. Despite this, the roles go back and forth about the block added by proxmox.

I don't believe these SSH settings are necessary if clustering is disabled, correct?

I've also added a `pve_manage_ssh` (default 'yes'), which would allow someone that uses clustering to still manage their SSH config via a different role. Since this defaults to yes, this won't affect the current behavior when the role is upgraded.

Thanks!