### PR TITLE
Support for adding authentication realms to domains.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ pve_groups: [] # List of group definitions to manage in PVE. See section on User
 pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 pve_storages: [] # List of storages to manage in PVE. See section on Storage Management.
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
+pve_domains_cfg: {} # List of realms to use as authentication sources in the PVE domains.cfg config file.
 ```
 
 To enable clustering with this role, configure the following variables appropriately:
@@ -459,6 +460,36 @@ pve_cluster_ha_groups:
 
 All configuration options supported in the datacenter.cfg file are documented in the
 [Proxmox manual datacenter.cfg section][datacenter-cfg].
+
+You can set realms / domains as authentication sources in the `domains.cfg` configuration file.
+If this file is not present, only the `Linux PAM` and `Proxmox VE authentication server` realms
+are available. Supported types are `pam`, `pve`, `ad` and `ldap`.
+One realm should have the `default: 1` property to mark it as the default:
+
+```
+pve_domains_cfg:
+    - name: pam
+      type: pam
+      comment: Linux PAM standard authentication
+    - name: pve
+      type: pve
+      comment: Proxmox VE authentication server
+    - name: AD
+      type: ad
+      comment: Active Directory authentication
+      domain: yourdomain.com
+      server1: dc01.yourdomain.com
+      default: 1
+      secure: 1
+      server2: dc02.yourdomain.com
+    - name: LDAP
+      type: ldap
+      base_dn: CN=Users,dc=yourdomain,dc=com
+      server1: ldap1.yourdomain.com
+      user_attr: uid
+      secure: 1
+      server2: ldap2.yourdomain.com
+```
 
 ## Dependencies
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -262,6 +262,47 @@
     - not pve_cluster_enabled | bool or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])
     - pve_datacenter_cfg | length > 0
 
+- name: Check domains.cfg exists
+  stat:
+    path: "/etc/pve/domains.cfg"
+  register: _domains_cfg
+  when:
+    - not pve_cluster_enabled or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])
+    - pve_domains_cfg | length > 0
+
+- name: Create domains.cfg if it does not exist
+  file:
+    path: "/etc/pve/domains.cfg"
+    state: "touch"
+  when:
+    - not pve_cluster_enabled | bool or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])
+    - pve_domains_cfg | length > 0
+    - not _domains_cfg.stat.exists
+
+- name: Configure domains.cfg
+  # The parser for domains.cfg requires a blank line after each domain,
+  # and there's a TAB character before printing each key / value pair for a domain
+  copy:
+    dest: "/etc/pve/domains.cfg"
+    owner: "root"
+    group: "www-data"
+    mode: "0640"
+    content: |
+      {% for domain in pve_domains_cfg %}
+      {{ domain.type }}: {{ domain.name }}
+      {% for k,v in domain.items() %}
+      {% if k != 'name' %}
+      {% if k != 'type' %}
+      	{{ k }} {{ v }}
+      {% endif %}
+      {% endif %}
+      {% endfor %}
+
+      {% endfor %}
+  when:
+    - not pve_cluster_enabled | bool or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])
+    - pve_domains_cfg | length > 0
+
 - import_tasks: ssl_config.yml
   when:
     - pve_ssl_private_key is defined


### PR DESCRIPTION
This branch somewhat addresses issue #23 with support for adding non-default authentication domains / realms to `/etc/pve/domains.cfg` in a similar fashion to the way `/etc/pve/datacenter.cfg` is handled. This code overwrites the configuration file directly, it would be preferable if a true Python module were written to use the [domains REST API](https://pve.proxmox.com/pve-docs/api-viewer/#/access/domains/{realm}) but for now this appears to be sufficient to add Active Directory authentication to login to the web UI.

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>