### PR TITLE
Get rid of the Enterprise repo first

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,28 @@
     name: os-prober
     state: absent
 
+- block:
+  - name: Remove automatically installed PVE Enterprise repo configuration
+    apt_repository:
+      repo: "{{ item }}"
+      filename: pve-enterprise
+      state: absent
+    with_items:
+      - "deb https://enterprise.proxmox.com/debian {{ ansible_distribution_release }} pve-enterprise"
+      - "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
+
+  - name: Remove subscription check wrapper function in web UI
+    patch:
+      src: "00_remove_checked_command_{{ ansible_distribution_release }}.patch"
+      basedir: /
+      strip: 1
+      backup: yes
+    when:
+      - "pve_remove_subscription_warning | bool"
+
+  when:
+    - "'pve-no-subscription' in pve_repository_line"
+
 - name: Add Proxmox repository
   apt_repository:
     repo: "{{ pve_repository_line }}"
@@ -130,28 +152,6 @@
   retries: 2
   register: _proxmox_install
   until: _proxmox_install is succeeded
-
-- block:
-  - name: Remove automatically installed PVE Enterprise repo configuration
-    apt_repository:
-      repo: "{{ item }}"
-      filename: pve-enterprise
-      state: absent
-    with_items:
-      - "deb https://enterprise.proxmox.com/debian {{ ansible_distribution_release }} pve-enterprise"
-      - "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
-
-  - name: Remove subscription check wrapper function in web UI
-    patch:
-      src: "00_remove_checked_command_{{ ansible_distribution_release }}.patch"
-      basedir: /
-      strip: 1
-      backup: yes
-    when:
-      - "pve_remove_subscription_warning | bool"
-
-  when:
-    - "'pve-no-subscription' in pve_repository_line"
 
 - import_tasks: kernel_updates.yml
 


### PR DESCRIPTION
Git rid of the Enterprise repo first, or else "Add Proxmox repository" fails when it tries to
"apt update" with an "Unthauthorized IP" error for sites that don't have a Proxmox subscription.

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>