### PR TITLE
Allow crush rule 'type' to be overriden to something other than host

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,11 +600,15 @@ pve_ceph_osds:
   - device: /dev/sdd
     block.db: /dev/sdb1
 # Crush rules for different storage classes
+# By default 'type' is set to host, you can find valid types at (https://docs.ceph.com/en/latest/rados/operations/crush-map/)
+# listed under 'TYPES AND BUCKETS'
 pve_ceph_crush_rules:
   - name: ssd
     class: ssd
+    type: osd
   - name: hdd
     class: hdd
+    type: host
 # 2 Ceph pools for VM disks which will also be defined as Proxmox storages
 # Using different CRUSH rules
 pve_ceph_pools:

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -97,7 +97,7 @@
   - name: Create Ceph CRUSH rules
     command: >-
       ceph osd crush rule create-replicated
-      {{ item.name }} default host {{ item.class | default("") }}
+      {{ item.name }} default {{ item.type | default ("host") }} {{ item.class | default("") }}
     when: item.name not in _ceph_crush.stdout_lines
     with_items: '{{ pve_ceph_crush_rules }}'
 


### PR DESCRIPTION
Allows users to specify the crush rule map type for something other than 'host'