### PR TITLE
Fix trusting Proxmox' packaging key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,6 +75,11 @@
         "{{ hostvars[item].ansible_hostname }}"
       ]
 
+- name: Ensure gpg is installed
+  apt:
+    name: gpg
+    state: present
+
 - name: Trust Proxmox' packaging key
   apt_key:
     data: "{{ lookup('file', pve_release_key) }}"


### PR DESCRIPTION
The ansible `apt_key` module requires gpg to be installed. The gpg package is not present when installing Debian without system tools.