### PR TITLE
Expand conditionals when pve_cluster_enabled: false

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
 
 
       {% endfor %}"
+  when: "pve_cluster_enabled | bool"
 
 - name: Remove conflicting lines in hosts files
   lineinfile:
@@ -74,6 +75,7 @@
         "{{ hostvars[item].ansible_fqdn }}",
         "{{ hostvars[item].ansible_hostname }}"
       ]
+  when: "pve_cluster_enabled | bool"
 
 - name: Trust Proxmox' packaging key
   apt_key:
@@ -168,7 +170,9 @@
     src: "01_pass_correct_format_for_linkX.patch"
     basedir: /
     strip: 1
-  when: ansible_distribution_release == 'buster'
+  when:
+    - ansible_distribution_release == 'buster'
+    - pve_cluster_enabled | bool
 
 - import_tasks: pve_cluster_config.yml
   when: "pve_cluster_enabled | bool"


### PR DESCRIPTION
Unneeded modifications to /etc/hosts and to pvecm are now disabled when pve_cluster_enabled: false.  

Fixes issue #107