### PR TITLE
Support management of user roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 fetch/
 .vagrant/
+/.settings/

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ pve_ceph_crush_rules: [] # List of CRUSH rules to create
 # pve_ssl_private_key: "" # Should be set to the contents of the private key to use for HTTPS
 # pve_ssl_certificate: "" # Should be set to the contents of the certificate to use for HTTPS
 pve_ssl_letsencrypt: false # Specifies whether or not to obtain a SSL certificate using Let's Encrypt
+pve_roles: [] # Added more roles with specific privileges. See section on User Management.
 pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
 pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 pve_storages: [] # List of storages to manage in PVE. See section on Storage Management.
@@ -513,10 +514,19 @@ pve_users:
 Refer to `library/proxmox_user.py` [link][user-module] and
 `library/proxmox_group.py` [link][group-module] for module documentation.
 
-For managing ACLs, a similar module is employed, but the main difference is that
-most of the parameters only accept lists (subject to change):
+For managing roles and ACLs, a similar module is employed, but the main
+difference is that most of the parameters only accept lists (subject to
+change):
 
 ```
+pve_roles:
+  - name: Monitoring
+    privileges:
+      - "Sys.Modify"
+      - "Sys.Audit"
+      - "Datastore.Audit"
+      - "VM.Monitor"
+      - "VM.Audit"
 pve_acls:
   - path: /
     roles: [ "Administrator" ]
@@ -529,7 +539,8 @@ pve_acls:
       - test_users
 ```
 
-Refer to `library/proxmox_acl.py` [link][acl-module] for module documentation.
+Refer to `library/proxmox_role.py` [link][user-module] and 
+`library/proxmox_acl.py` [link][acl-module] for module documentation.
 
 ## Storage Management
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
----
 # defaults file for ansible-role-proxmox
+---
 pve_group: proxmox
 pve_fetch_directory: fetch
 pve_repository_line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
@@ -34,9 +34,14 @@ pve_cluster_clustername: "{{ pve_group }}"
 pve_datacenter_cfg: {}
 pve_cluster_ha_groups: []
 pve_ssl_letsencrypt: false
+# additional roles for your cluster (f.e. for monitoring)
+pve_roles: []
+# additional groups
 pve_groups: []
+# additional users (except root)
 pve_users: []
 pve_acls: []
 pve_storages: []
+# SSH port for communication between cluster nodes
 pve_ssh_port: 22
 pve_manage_ssh: true

--- a/library/proxmox_role.py
+++ b/library/proxmox_role.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'lae'
+}
+
+DOCUMENTATION = '''
+---
+module: proxmox_role
+
+short_description: Manages the Access Control List in Proxmox
+
+options:
+    name:
+        required: true
+        description:
+            - name of the role.
+    privileges:
+        required: true
+        type: list
+        description:
+            - Specifies a list of PVE privileges for the given role.
+    state:
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Specifies whether this role should exist or not.
+
+author:
+    - Thoralf Rickert-Wendt (@trickert76)
+'''
+
+EXAMPLES = '''
+- name: Create a role for monitoring with given privileges
+  proxmox_role:
+    name: "monitoring"
+    privileges: [ "Sys.Modify", "Sys.Audit", "Datastore.Audit", "VM.Monitor", "VM.Audit" ]
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.pvesh import ProxmoxShellError
+import ansible.module_utils.pvesh as pvesh
+
+class ProxmoxRole(object):
+    def __init__(self, module):
+        self.module = module
+        self.name = module.params['name']
+        self.privileges = module.params['privileges']
+        self.state = module.params['state']
+
+        try:
+            self.existing_roles = pvesh.get("access/roles")
+        except ProxmoxShellError as e:
+            self.module.fail_json(msg=e.message, status_code=e.status_code)
+
+        self.parse_roles()
+
+    def parse_roles(self):
+        self.roles = []
+        for existing_role in self.existing_roles:
+          self.roles.append(existing_role.get('roleid'))
+
+    def lookup(self):
+        self.roles = []
+        for existing_role in self.existing_roles:
+          if existing_role.get('roleid') == self.name:
+            args = {}
+            args['roleid'] = existing_role.get('roleid')
+            args['privs'] = ','.join(sorted(existing_role.get('privs').split(',')))
+            return args
+        
+        return None
+
+    def exists(self):
+        if self.name not in self.roles:
+          return False
+
+        return True
+
+    def prepare_role_args(self, appendKey=True):
+        args = {}
+        if appendKey:
+          args['roleid'] = self.name
+        args['privs'] = ','.join(sorted(self.privileges))
+
+        return args
+    
+    def remove_role(self):
+        try:
+            pvesh.delete("access/roles/{}".format(self.name))
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def create_role(self):
+        new_role = self.prepare_role_args()
+
+        try:
+            pvesh.create("access/roles", **new_role)
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def modify_role(self):
+        existing_role = self.lookup()
+        modified_role = self.prepare_role_args(appendKey=False)
+        updated_fields = []
+        error = None
+
+        for key in modified_role:
+            if key not in existing_role:
+                updated_fields.append(key)
+            else:
+                new_value = modified_role.get(key)
+                old_value = existing_role.get(key)
+                if isinstance(old_value, list):
+                    old_value = ','.join(sorted(old_value))
+                if isinstance(new_value, list):
+                    new_value = ','.join(sorted(new_value))
+                    
+                if new_value != old_value:
+                    updated_fields.append(key)
+
+        if self.module.check_mode:
+            self.module.exit_json(changed=bool(updated_fields), expected_changes=updated_fields)
+
+        if not updated_fields:
+            # No changes necessary
+            return (updated_fields, error)
+
+        try:
+            pvesh.set("access/roles/{}".format(self.name), **modified_role)
+        except ProxmoxShellError as e:
+            error = e.message
+
+        return (updated_fields, error)
+
+def main():
+    # Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html
+    module = AnsibleModule(
+        argument_spec = dict(
+            name=dict(type='str', required=True),
+            privileges=dict(type='list', required=True),
+            state=dict(default='present', choices=['present', 'absent'], type='str')
+        ),
+        supports_check_mode=True
+    )
+
+    role = ProxmoxRole(module)
+
+    changed = False
+    error = None
+    result = {}
+    result['name'] = role.name
+    result['state'] = role.state
+    result['changed'] = False
+
+    if role.state == 'absent':
+        if role.exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = role.remove_role()
+    elif role.state == 'present':
+        if not role.exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = role.create_role()
+        else:
+            (updated_fields, error) = role.modify_role()
+
+            if updated_fields:
+                changed = True
+                result['updated_fields'] = updated_fields
+
+    if error is not None:
+        module.fail_json(name=role.name, msg=error)
+
+    result['changed'] = changed
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -185,6 +185,14 @@
 - import_tasks: ceph.yml
   when: "pve_ceph_enabled | bool"
 
+- name: Configure Proxmox roles
+  proxmox_role:
+    name: "{{ item.name }}"
+    privileges: "{{ item.privileges }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ pve_roles }}"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+
 - name: Configure Proxmox groups
   proxmox_group:
     name: "{{ item.name }}"

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -20,6 +20,14 @@ pve_cluster_ha_groups:
     comment: "Resources on proxmox-5-01"
     nodes: proxmox-5-01
     restricted: 1
+pve_roles:
+  - name: Monitoring
+    privileges:
+      - "Sys.Modify"
+      - "Sys.Audit"
+      - "Datastore.Audit"
+      - "VM.Monitor"
+      - "VM.Audit"
 pve_groups:
   - name: Admins
     comment: Administrators of this PVE cluster


### PR DESCRIPTION
I've added a new module for managing pve roles (because Icinga monitoring user needs a special role and I don't want to add it manually on all clusters). I was able to create and remove a role. 