### PR TITLE
change acl "propagate" attribute to integer

### DIFF
--- a/library/proxmox_acl.py
+++ b/library/proxmox_acl.py
@@ -99,7 +99,7 @@ class ProxmoxACL(object):
             for constituent in constituents:
                 self.acls.append({
                     "path": self.path,
-                    "propagate": "1", # possibly make this configurable in the module later
+                    "propagate": 1, # possibly make this configurable in the module later
                     "roleid": role,
                     "type": constituent[0],
                     "ugid": constituent[1]


### PR DESCRIPTION
The `get access/acl` call returns `propagate` as an integer value. However the module was defining it as a string. This resulted in the module constantly redefining the ACL and reporting it as "changed" when nothing was actually changing.

Not sure if at some point in the past this actually was a string, but as of 6.3 it is an integer.