### PR TITLE
Identify kernel information via /lib/modules instead of boot parameters

### DIFF
--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -21,44 +21,31 @@ def main():
 
     params = module.params
 
-    # Much of the following is reimplemented from /usr/share/grub/grub-mkconfig_lib
-    kernels = []
-    # Collect a list of possible installed kernels
-    for filename in glob.glob("/boot/vmlinuz-*") + glob.glob("/vmlinuz-*") + \
-                    glob.glob("/boot/kernel-*"):
-        if ".dpkg-" in filename:
-            continue
-        if filename.endswith(".rpmsave") or filename.endswith(".rpmnew"):
-            continue
-        kernels.append(filename)
+    # Collect a list of installed kernels
+    kernels = glob.glob("/lib/modules/*")
 
+    # Identify path to the latest kernel
     latest_kernel = ""
-    re_prefix = re.compile("[^-]*-")
-    re_attributes = re.compile("[._-](pre|rc|test|git|old|trunk)")
     for kernel in kernels:
-        right = re.sub(re_attributes, "~\1", re.sub(re_prefix, '', latest_kernel, count=1))
-        if not right:
+        if not latest_kernel:
             latest_kernel = kernel
             continue
-        left = re.sub(re_attributes, "~\1", re.sub(re_prefix, '', kernel, count=1))
+        # These splits remove the path and get the base directory name, which
+        # should be something like 5.4.78-1-pve, that we can compare
+        right = latest_kernel.split("/")[-1]
+        left = kernel.split("/")[-1]
         cmp_str = "gt"
-        if left.endswith(".old") and not right.endswith(".old"):
-            left = left[:-4]
-        if right.endswith(".old") and not left.endswith(".old"):
-            right = right[:-4]
-            cmp_str = "ge"
         if subprocess.call(["dpkg", "--compare-versions", left, cmp_str, right]) == 0:
             latest_kernel = kernel
 
-    # This will likely output a path that considers the boot partition as /
-    # e.g. /vmlinuz-4.4.44-1-pve
-    booted_kernel = to_text(subprocess.check_output(["grep", "-o", "-P", "(?<=BOOT_IMAGE=).*?(?= )", "/proc/cmdline"]).strip())
+    booted_kernel = "/lib/modules/{}".format(to_text(subprocess.check_output(["uname", "-r"]).strip))
 
     booted_kernel_package = ""
     old_kernel_packages = []
-
     if params['lookup_packages']:
         for kernel in kernels:
+            # Identify the currently booted kernel and unused old kernels by
+            # querying which packages owns the directory in /lib/modules
             if kernel.split("/")[-1] == booted_kernel.split("/")[-1]:
                 booted_kernel_package = to_text(subprocess.check_output(["dpkg-query", "-S", kernel])).split(":")[0]
             elif kernel != latest_kernel:


### PR DESCRIPTION
`collect_kernel_info.py` fails to identify the booted kernel when running without GRUB. This changeset updates the module to be bootloader-agnostic. Although I'm not sure if this is a comprehensive enough check...

```
TASK [lae.proxmox : Collect kernel package information] ********************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: subprocess.CalledProcessError: Command '['grep', '-o', '-P', '(?<=BOOT_IMAGE=).*?(?= )', '/proc/cmdline']' returned non-zero exit status 1.
fatal: [internal_host]: FAILED! => {"changed": false, "module_stderr": "Shared connection to internal_host closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1611028174.842685-36181-267069839226487/AnsiballZ_collect_kernel_info.py\", line 102, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1611028174.842685-36181-267069839226487/AnsiballZ_collect_kernel_info.py\", line 94, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1611028174.842685-36181-267069839226487/AnsiballZ_collect_kernel_info.py\", line 40, in invoke_module\r\n    runpy.run_module(mod_name='ansible.modules.collect_kernel_info', init_globals=None, run_name='__main__', alter_sys=True)\r\n  File \"/usr/lib/python3.7/runpy.py\", line 205, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/lib/python3.7/runpy.py\", line 96, in _run_module_code\r\n    mod_name, mod_spec, pkg_name, script_name)\r\n  File \"/usr/lib/python3.7/runpy.py\", line 85, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_collect_kernel_info_payload_1ld0tvgo/ansible_collect_kernel_info_payload.zip/ansible/modules/collect_kernel_info.py\", line 72, in <module>\r\n  File \"/tmp/ansible_collect_kernel_info_payload_1ld0tvgo/ansible_collect_kernel_info_payload.zip/ansible/modules/collect_kernel_info.py\", line 55, in main\r\n  File \"/usr/lib/python3.7/subprocess.py\", line 395, in check_output\r\n    **kwargs).stdout\r\n  File \"/usr/lib/python3.7/subprocess.py\", line 487, in run\r\n    output=stdout, stderr=stderr)\r\nsubprocess.CalledProcessError: Command '['grep', '-o', '-P', '(?<=BOOT_IMAGE=).*?(?= )', '/proc/cmdline']' returned non-zero exit status 1.\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```