### PR TITLE
Add autoscale mode for pool Ceph configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ To enable clustering with this role, configure the following variables appropria
 ```
 pve_cluster_enabled: no # Set this to yes to configure hosts to be clustered together
 pve_cluster_clustername: "{{ pve_group }}" # Should be set to the name of the PVE cluster
+pve_manage_hosts_enabled : yes # Set this to no to NOT configure hosts file (case of using vpn and hosts file is already configured)
 ```
 
 The following variables are used to provide networking information to corosync.

--- a/README.md
+++ b/README.md
@@ -649,6 +649,13 @@ pve_ceph_pools:
     storage: true
     size: 2
     min-size: 1
+# This Ceph pool uses custom autoscale mode : "off" | "on" | "warn"> (default = "warn")
+  - name: vm-storage,
+    pgs: 128,
+    rule: replicated_rule,
+    application: rbd,
+    autoscale_mode: "on",
+    storage: true,
 pve_ceph_fs:
 # A CephFS filesystem not defined as a Proxmox storage
   - name: backup

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-nautilus 
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}" # Ceph public network
 # pve_ceph_cluster_network: "" # Optional, if the ceph cluster network is different from the public network (see https://pve.proxmox.com/pve-docs/chapter-pveceph.html#pve_ceph_install_wizard)
 pve_ceph_mon_group: "{{ pve_group }}" # Host group containing all Ceph monitor hosts
+pve_ceph_mgr_group: "{{ pve_group }}" # Host group containing all Ceph manager hosts
 pve_ceph_mds_group: "{{ pve_group }}" # Host group containing all Ceph metadata server hosts
 pve_ceph_osds: [] # List of OSD disks
 pve_ceph_pools: [] # List of pools to create

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ pve_ceph_crush_rules: []
 # pve_ssl_certificate: "contents of certificate"
 pve_cluster_enabled: no
 pve_cluster_clustername: "{{ pve_group }}"
+pve_manage_hosts_enabled: yes
 # pve_cluster_addr0: "{{ ansible_default_ipv4.address }}"
 # pve_cluster_addr1: "{{ ansible_eth1.ipv4.address }}
 pve_datacenter_cfg: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ pve_ceph_enabled: false
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'stretch' %}ceph-luminous stretch{% else %}ceph-nautilus buster{% endif %} main"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}"
 pve_ceph_mon_group: "{{ pve_group }}"
+pve_ceph_mgr_group: "{{ pve_group }}"
 pve_ceph_mds_group: "{{ pve_group }}"
 pve_ceph_osds: []
 pve_ceph_pools: []

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -45,6 +45,12 @@
     creates: '/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/'
   when: "inventory_hostname != groups[pve_ceph_mon_group][0]"
 
+- name: Create additional Ceph managers
+  command: 'pveceph mgr create'
+  args:
+    creates: '/var/lib/ceph/mgr/ceph-{{ ansible_hostname }}/'
+  loop: '{{ pve_ceph_mgr_group }}'
+
 - block:
     - name: Get existing ceph volumes
       ceph_volume:

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -161,6 +161,9 @@
         {% if 'rule' in item %}
         --crush_rule {{ item.rule }}
         {% endif %}
+        {% if 'autoscale_mode' in item %}
+        --pg_autoscale_mode {{ item.autoscale_mode }}
+        {% endif %}
         {% if 'pgs' in item %}
         --pg_num {{ item.pgs }}
         {% endif %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 
       {% endfor %}"
-  when: "pve_cluster_enabled | bool"
+  when: "pve_manage_hosts_enabled | bool"
 
 - name: Remove conflicting lines in hosts files
   lineinfile:
@@ -76,7 +76,7 @@
         "{{ hostvars[item].ansible_fqdn }}",
         "{{ hostvars[item].ansible_hostname }}"
       ]
-  when: "pve_cluster_enabled | bool"
+  when: "pve_manage_hosts_enabled | bool"
 
 - name: Ensure gpg is installed
   apt:
@@ -135,6 +135,7 @@
   apt:
     name: "{{ _pve_install_packages }}"
     state: "{{ 'latest' if pve_run_proxmox_upgrades else 'present' }}"
+    update_cache: yes
   retries: 2
   register: _proxmox_install
   until: _proxmox_install is succeeded
@@ -155,6 +156,7 @@
         basedir: /
         strip: 1
         backup: yes
+      ignore_errors: yes
       when:
         - "pve_remove_subscription_warning | bool"
   when:


### PR DESCRIPTION
Ability to manage autoscale mode for pool's Ceph configuration

This Ceph pool uses custom autoscale mode : "off" | "on" | "warn"> (default = "warn")
```
  - name: vm-storage,
    pgs: 128,
    rule: replicated_rule,
    application: rbd,
    autoscale_mode: "on",
    storage: true,
```