### PR TITLE
Add autoscale mode for Ceph pool configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,13 @@ pve_ceph_pools:
     storage: true
     size: 2
     min-size: 1
+# This Ceph pool uses custom autoscale mode : "off" | "on" | "warn"> (default = "warn")
+  - name: vm-storage,
+    pgs: 128,
+    rule: replicated_rule,
+    application: rbd,
+    autoscale_mode: "on",
+    storage: true,
 pve_ceph_fs:
 # A CephFS filesystem not defined as a Proxmox storage
   - name: backup

--- a/README.md
+++ b/README.md
@@ -650,12 +650,12 @@ pve_ceph_pools:
     size: 2
     min-size: 1
 # This Ceph pool uses custom autoscale mode : "off" | "on" | "warn"> (default = "warn")
-  - name: vm-storage,
-    pgs: 128,
-    rule: replicated_rule,
-    application: rbd,
-    autoscale_mode: "on",
-    storage: true,
+  - name: vm-storage
+    pgs: 128
+    rule: replicated_rule
+    application: rbd
+    autoscale_mode: "on"
+    storage: true
 pve_ceph_fs:
 # A CephFS filesystem not defined as a Proxmox storage
   - name: backup

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -161,6 +161,9 @@
         {% if 'rule' in item %}
         --crush_rule {{ item.rule }}
         {% endif %}
+        {% if 'autoscale_mode' in item %}
+        --pg_autoscale_mode {{ item.autoscale_mode }}
+        {% endif %}
         {% if 'pgs' in item %}
         --pg_num {{ item.pgs }}
         {% endif %}


### PR DESCRIPTION
Ability to manage autoscale mode for pool's Ceph configuration

This Ceph pool uses custom autoscale mode : "off" | "on" | "warn"> (default = "warn")
```
  - name: vm-storage,
    pgs: 128,
    rule: replicated_rule,
    application: rbd,
    autoscale_mode: "on",
    storage: true,
```