### PR TITLE
Correct list of required attrs for RBD storages

### DIFF
--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -318,7 +318,7 @@ def main():
         supports_check_mode=True,
         required_if=[
             ["type", "dir", ["path", "content"]],
-            ["type", "rbd", ["pool", "content", "monhost", "username"]],
+            ["type", "rbd", ["pool", "content"]],
             ["type", "nfs", ["server", "content", "export"]],
             ["type", "lvm", ["vgname", "content"]],
             ["type", "lvmthin", ["vgname", "thinpool", "content"]],


### PR DESCRIPTION
When you configure a pool with rdb, set username and path is not required.