### PR TITLE
Add the ability to disable hosts file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ To enable clustering with this role, configure the following variables appropria
 ```
 pve_cluster_enabled: no # Set this to yes to configure hosts to be clustered together
 pve_cluster_clustername: "{{ pve_group }}" # Should be set to the name of the PVE cluster
+pve_manage_hosts_enabled : yes # Set this to no to NOT configure hosts file (case of using vpn and hosts file is already configured)
 ```
 
 The following variables are used to provide networking information to corosync.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ pve_ceph_crush_rules: []
 # pve_ssl_certificate: "contents of certificate"
 pve_cluster_enabled: no
 pve_cluster_clustername: "{{ pve_group }}"
+pve_manage_hosts_enabled: yes
 # pve_cluster_addr0: "{{ ansible_default_ipv4.address }}"
 # pve_cluster_addr1: "{{ ansible_eth1.ipv4.address }}
 pve_datacenter_cfg: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 
       {% endfor %}"
-  when: "pve_cluster_enabled | bool"
+  when: "pve_manage_hosts_enabled | bool"
 
 - name: Remove conflicting lines in hosts files
   lineinfile:
@@ -76,7 +76,7 @@
         "{{ hostvars[item].ansible_fqdn }}",
         "{{ hostvars[item].ansible_hostname }}"
       ]
-  when: "pve_cluster_enabled | bool"
+  when: "pve_manage_hosts_enabled | bool"
 
 - name: Ensure gpg is installed
   apt:
@@ -135,6 +135,7 @@
   apt:
     name: "{{ _pve_install_packages }}"
     state: "{{ 'latest' if pve_run_proxmox_upgrades else 'present' }}"
+    update_cache: yes
   retries: 2
   register: _proxmox_install
   until: _proxmox_install is succeeded
@@ -155,6 +156,7 @@
         basedir: /
         strip: 1
         backup: yes
+      ignore_errors: yes
       when:
         - "pve_remove_subscription_warning | bool"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 
       {% endfor %}"
-  when: "pve_manage_hosts_enabled | bool"
+  when: "pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
 - name: Remove conflicting lines in hosts files
   lineinfile:
@@ -76,7 +76,7 @@
         "{{ hostvars[item].ansible_fqdn }}",
         "{{ hostvars[item].ansible_hostname }}"
       ]
-  when: "pve_manage_hosts_enabled | bool"
+  when: "pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
 - name: Ensure gpg is installed
   apt:
@@ -135,7 +135,6 @@
   apt:
     name: "{{ _pve_install_packages }}"
     state: "{{ 'latest' if pve_run_proxmox_upgrades else 'present' }}"
-    update_cache: yes
   retries: 2
   register: _proxmox_install
   until: _proxmox_install is succeeded
@@ -156,7 +155,6 @@
         basedir: /
         strip: 1
         backup: yes
-      ignore_errors: yes
       when:
         - "pve_remove_subscription_warning | bool"
   when:


### PR DESCRIPTION
I've configured several servers at different providers to be linked together throw VPN (i'm using Tinc) I that case, my hosts file have to be configured before launching proxmox tasks.
By default, it's change nothing compare to before. If you set the variable to "no", then tasks configuring hosts file are skipped