### PR TITLE
Add ability to specify on wich nodes Ceph is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ pve_ceph_enabled: false # Specifies wheter or not to install and configure Ceph 
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-nautilus buster main" # apt-repository configuration. Will be automatically set for 5.x and 6.x (Further information: https://pve.proxmox.com/wiki/Package_Repositories)
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}" # Ceph public network
 # pve_ceph_cluster_network: "" # Optional, if the ceph cluster network is different from the public network (see https://pve.proxmox.com/pve-docs/chapter-pveceph.html#pve_ceph_install_wizard)
+pve_ceph_nodes: "{{ pve_group }}" # Host group containing all Ceph nodes
 pve_ceph_mon_group: "{{ pve_group }}" # Host group containing all Ceph monitor hosts
 pve_ceph_mgr_group: "{{ pve_ceph_mon_group }}" # Host group containing all Ceph manager hosts
 pve_ceph_mds_group: "{{ pve_group }}" # Host group containing all Ceph metadata server hosts
@@ -616,6 +617,7 @@ following definitions show some of the configurations that are possible.
 pve_ceph_enabled: true
 pve_ceph_network: '172.10.0.0/24'
 pve_ceph_cluster_network: '172.10.1.0/24'
+pve_ceph_nodes: "ceph_nodes"
 pve_ceph_osds:
   # OSD with everything on the same device
   - device: /dev/sdc
@@ -677,6 +679,8 @@ pve_ceph_fs:
 
 `pve_ceph_network` by default uses the `ipaddr` filter, which requires the
 `netaddr` library to be installed and usable by your Ansible controller.
+
+`pve_ceph_nodes` by default uses the `pve_group`, this parameter allows to specify on which nodes install Ceph (e.g. if you don't want to install Ceph on all your nodes).
 
 `pve_ceph_osds` by default creates unencrypted ceph volumes. To use encrypted volumes the parameter `encrypted` has to be set per drive to `true`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ pve_zfs_enabled: no
 pve_ceph_enabled: false
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'stretch' %}ceph-luminous stretch{% else %}ceph-nautilus buster{% endif %} main"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}"
-pve_ceph_nodes: "ceph_nodes"
+pve_ceph_nodes: "{{ pve_group }}"
 pve_ceph_mon_group: "{{ pve_group }}"
 pve_ceph_mgr_group: "{{ pve_ceph_mon_group }}"
 pve_ceph_mds_group: "{{ pve_group }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ pve_zfs_enabled: no
 pve_ceph_enabled: false
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'stretch' %}ceph-luminous stretch{% else %}ceph-nautilus buster{% endif %} main"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}"
+pve_ceph_nodes: "ceph_nodes"
 pve_ceph_mon_group: "{{ pve_group }}"
 pve_ceph_mgr_group: "{{ pve_ceph_mon_group }}"
 pve_ceph_mds_group: "{{ pve_group }}"

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -43,7 +43,9 @@
   command: 'pveceph mon create'
   args:
     creates: '/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/'
-  when: "inventory_hostname != groups[pve_ceph_mon_group][0]"
+  when: 
+  - "inventory_hostname != groups[pve_ceph_mon_group][0]"
+  - "inventory_hostname in groups[pve_ceph_mon_group]"
 
 - name: Create additional Ceph managers
   command: 'pveceph mgr create'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,7 +107,9 @@
     filename: ceph
     state: present
   register: _pve_ceph_repo
-  when: "pve_ceph_enabled | bool"
+  when: 
+    - "pve_ceph_enabled | bool"
+    - "inventory_hostname in groups[pve_ceph_nodes]"
 
 - name: Run apt-get dist-upgrade on repository changes
   apt:
@@ -183,7 +185,9 @@
   when: "pve_cluster_enabled | bool"
 
 - import_tasks: ceph.yml
-  when: "pve_ceph_enabled | bool"
+  when: 
+    - "pve_ceph_enabled | bool"
+    - "inventory_hostname in groups[pve_ceph_nodes]"
 
 - name: Configure Proxmox roles
   proxmox_role:


### PR DESCRIPTION
Ability to choose on which nodes Ceph is installed.
This is very useful when you want to separate the 'compute nodes' and the 'storage nodes' on Proxmox cluster.