### PR TITLE
Check mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Now for the flesh of your playbook, `pve01`'s group variables. Create a file
 ```
 ---
 pve_group: pve01
-pve_fetch_directory: "fetch/{{ pve_group }}/"
 pve_watchdog: ipmi
 pve_ssl_private_key: "{{ lookup('file', pve_group + '/' + inventory_hostname + '.key') }}"
 pve_ssl_certificate: "{{ lookup('file', pve_group + '/' + inventory_hostname + '.pem') }}"
@@ -187,10 +186,6 @@ for the purposes of ensuring all hosts within that group can connect to each
 other and are clustered together. Note that the PVE cluster name will be set to
 this group name as well, unless otherwise specified by `pve_cluster_clustername`.
 Leaving this undefined will default to `proxmox`.
-
-`pve_fetch_directory` will be used to download the host public key and root user's
-public key from all hosts within `pve_group`. These are then uploaded to each
-host into the appropriate configuration files.
 
 `pve_watchdog` here enables IPMI watchdog support and configures PVE's HA
 manager to use it. Leave this undefined if you don't want to configure it.
@@ -381,7 +376,6 @@ serially during a maintenance period.) It will also enable the IPMI watchdog.
 ```
 [variable]: [default] #[description/purpose]
 pve_group: proxmox # host group that contains the Proxmox hosts to be clustered together
-pve_fetch_directory: fetch/ # local directory used to download root public keys from each host to
 pve_repository_line: "deb http://download.proxmox.com/debian/pve stretch pve-no-subscription" # apt-repository configuration - change to enterprise if needed (although TODO further configuration may be needed)
 pve_remove_subscription_warning: true # patches the subscription warning messages in proxmox if you are using the community edition
 pve_extra_packages: [] # Any extra packages you may want to install, e.g. ngrep

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # defaults file for ansible-role-proxmox
 pve_group: proxmox
-pve_fetch_directory: fetch
 pve_repository_line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
 pve_remove_subscription_warning: true
 pve_extra_packages: []

--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -14,11 +14,6 @@ def main():
         supports_check_mode=True
     )
 
-    # This module only performs diagnostics, so it doesn't actually change anything
-    # During actual usage we return "changed" depending on booted kernel status
-    if module.check_mode:
-        module.exit_json(changed=False)
-
     params = module.params
 
     # Much of the following is reimplemented from /usr/share/grub/grub-mkconfig_lib

--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -14,16 +14,14 @@
     ssh_key_comment: "root@{{ inventory_hostname_short }}"
 
 - name: Fetch root SSH public key
-  fetch:
+  slurp:
     src: /root/.ssh/id_rsa.pub
-    dest: "{{ pve_fetch_directory }}/{{ inventory_hostname }}/root_rsa.pub"
-    fail_on_missing: yes
-    flat: yes
+  register: proxmox_root_id_rsa_pub
 
 - name: Authorize all hosts' root SSH public keys
   authorized_key:
     user: root
-    key: "{{ lookup('file', pve_fetch_directory + '/' + item + '/root_rsa.pub') }}"
+    key: "{{ hostvars[item].proxmox_root_id_rsa_pub.content | b64decode }}"
   with_items: "{{ groups[pve_group] }}"
 
 - name: Configure SSH clients for connecting to PVE cluster hosts
@@ -52,10 +50,9 @@
     - reload sshd configuration
 
 - name: Fetch SSH public host keys
-  fetch:
+  slurp:
     src: "/etc/ssh/{{ item }}"
-    dest: "{{ pve_fetch_directory }}/{{ inventory_hostname }}/{{ item }}"
-    flat: yes
+  register: proxmox_ssh_public_host_keys
   with_items:
     - ssh_host_rsa_key.pub
     - ssh_host_ed25519_key.pub
@@ -73,10 +70,8 @@
     marker: "# {mark}: PVE host keys (managed by ansible)."
     content: |
       {% for host in groups[pve_group] %}
-      {% for keytype in ['rsa', 'ed25519', 'ecdsa'] %}
-      {%- set _keyfile = pve_fetch_directory + '/' + host + '/ssh_host_' + keytype + '_key.pub' -%}
-      {%- set _key = ' '.join(lookup('file', _keyfile).split()[:-1]) -%}
-      {{ hostvars[host].pve_cluster_ssh_addrs | join(",") }} {{ _key }}
+      {% for _key in hostvars[host].proxmox_ssh_public_host_keys.results %}
+      {{ hostvars[host].pve_cluster_ssh_addrs | join(",") }} {{ _key.content | b64decode }}
       {% endfor %}
       {% endfor %}
   when:


### PR DESCRIPTION
2 fixes for being able to run the role in `--check` mode.

One change switches from generating local files to storing data in variables. The `fetch` module doesn't run in check mode, and while we could change it to force it run in check mode, that alters the state of the local system, which goes against the intent of `--check`. Using a variable allows simplifying the code anyway.

The other change adjusts the `collect_kernel_info` module to always collect data, even in check mode. Otherwise tasks which run in check mode, and depend on the output, would fail.

Fixes #132 