### PR TITLE
Manage /etc/hosts, even when clustering is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,7 @@
     dest: /etc/hosts
     regexp: "^\\h*[0-9\\.]+.*({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }}).*$"
     line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    backup: yes
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
 - name: Ensure gpg is installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,6 +78,13 @@
       ]
   when: "pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
+- name: Define hostname in /etc/hosts for single-host installations
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^\\h*[0-9\\.]+.*({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }}).*$"
+    line: "{{ ansible_default_ipv4.address }}\t{{ ansible_fqdn }} {{ ansible_hostname }}"
+  when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
+
 - name: Ensure gpg is installed
   apt:
     name: gpg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^\\h*[0-9\\.]+.*({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }}).*$"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ hostvars[inventory_hostname].pve_cluster_addr0 }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     backup: yes
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,16 @@
 - name: Define hostname in /etc/hosts for single-host installations
   lineinfile:
     dest: /etc/hosts
-    regexp: "^\\h*[0-9\\.]+.*({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }}).*$"
+    regexp: |-
+      {# Match an IPv4/v6 address at the start #}
+      ^\\h*[0-9a-f:.]+
+      {# Match at least one whitespace, and any non-hostname names #}
+      (\\h+.*)?\\h
+      {# Match either our fqdn or hostname #}
+      ({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }})
+      {# Require there be a word boundary at the end of the name(s). #}
+      {# This can be any whitespace, or end-of-line. #}
+      (\\h+.*|\\h*)$
     line: "{{ hostvars[inventory_hostname].pve_cluster_addr0 }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     backup: yes
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^\\h*[0-9\\.]+.*({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }}).*$"
-    line: "{{ ansible_default_ipv4.address }}\t{{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
 - name: Ensure gpg is installed


### PR DESCRIPTION
This adds a separate task to define the hosts' names in `/etc/hosts` for a single-node (non-clustered) installation.

Do we also need to define `pvelocalhost` here?

Fixes lae/ansible-role-proxmox#126.