### PR TITLE
Don't run corosync on default IPv4 network by default

### DIFF
--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -31,10 +31,6 @@
       when: "pve_cluster_link1_addr is defined and ansible_distribution_release == 'buster'"
   when: "pve_cluster_addr1 is not defined"
 
-- name: Define pve_cluster_addr0 if not provided
-  set_fact:
-    pve_cluster_addr0: "{{ pve_cluster_addr0 | default(_pve_cluster_addr0) }}"
-
 - name: Calculate list of SSH addresses
   set_fact:
     pve_cluster_ssh_addrs: >-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,3 @@
 # vars file for ansible-role-proxmox
 pve_base_dir: "/etc/pve"
 pve_cluster_conf: "{{ pve_base_dir }}/corosync.conf"
-
-# defaults that need to be host facts
-_pve_cluster_addr0: "{{ ansible_default_ipv4.address }}"


### PR DESCRIPTION
This is error prone, if the host does not have IPv4 connectivity, and
worse this would run the corosync network on a public network, which
isn't an overall great design.

I believe it is more reasonable to have users of the role explicitly
decide on their cluster network.

---

In the first case `ansible_default_ipv4` is an empty attribute set and the task fails when accessing `.address` on it.

This strictly improves compatibility with IPv6 only hypervisors.