### PR TITLE
Don't manage SSH ciphers on bullseye 

### DIFF
--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -85,3 +85,13 @@
     insertbefore: BOF
     create: yes
     dest: /root/.ssh/config
+    state: present
+  when: pve_ssh_ciphers is defined
+
+- name: Drop PVE-provided ciphers, when undefined
+  lineinfile:
+    regexp: "^Ciphers .*"
+    dest: /root/.ssh/config
+    state: absent
+  when: pve_ssh_ciphers is not defined
+

--- a/vars/debian-bullseye.yml
+++ b/vars/debian-bullseye.yml
@@ -1,5 +1,4 @@
 ---
 pve_release_key: proxmox-ve-release-7.x.asc
 pve_release_key_id: DD4BA3917E23BF59
-pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-pacific bullseye main"


### PR DESCRIPTION
The OpenSSH daemon comes with reasonable defaults these days, so don't
try to manage that, by copying the same cipher list from release to
release.

Between Debian releases there is usually a large overlap over compatible
ciphers, so there shouldn't be any fear of breaking compatibility
between Proxmox VE releases either.

---

It might be reasonable to do the same on buster, but since I'm starting
a 7.0 cluster right now and I don't know the entire reasoning behind this
setting, I'm erring on the conservative side.