### PR TITLE
add files for debian 11 bullseye

### DIFF
--- a/files/00_remove_checked_command_bullseye.patch
+++ b/files/00_remove_checked_command_bullseye.patch
@@ -1,0 +1,80 @@
+diff -ur /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+--- /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
++++ /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+@@ -492,38 +492,6 @@
+ 	);
+     },
+
+-    checked_command: function(orig_cmd) {
+-	Proxmox.Utils.API2Request(
+-	    {
+-		url: '/nodes/localhost/subscription',
+-		method: 'GET',
+-		failure: function(response, opts) {
+-		    Ext.Msg.alert(gettext('Error'), response.htmlStatus);
+-		},
+-		success: function(response, opts) {
+-		    let res = response.result;
+-		    if (res === null || res === undefined || !res || res
+-			.data.status.toLowerCase() !== 'active') {
+-			Ext.Msg.show({
+-			    title: gettext('No valid subscription'),
+-			    icon: Ext.Msg.WARNING,
+-			    message: Proxmox.Utils.getNoSubKeyHtml(res.data.url),
+-			    buttons: Ext.Msg.OK,
+-			    callback: function(btn) {
+-				if (btn !== 'ok') {
+-				    return;
+-				}
+-				orig_cmd();
+-			    },
+-			});
+-		    } else {
+-			orig_cmd();
+-		    }
+-		},
+-	    },
+-	);
+-    },
+-
+     assemble_field_data: function(values, data) {
+         if (!Ext.isObject(data)) {
+ 	    return;
+@@ -12033,7 +12001,7 @@
+ 	let update_btn = new Ext.Button({
+ 	    text: gettext('Refresh'),
+ 	    handler: function() {
+-		Proxmox.Utils.checked_command(function() { apt_command('update'); });
++		apt_command('update');
+ 	    },
+ 	});
+
+diff -ur /usr/share/pve-manager/js/pvemanagerlib.js /usr/share/pve-manager/js/pvemanagerlib.js
+--- /usr/share/pve-manager/js/pvemanagerlib.js
++++ /usr/share/pve-manager/js/pvemanagerlib.js
+@@ -35005,7 +35005,7 @@
+ 		{
+ 		    text: gettext('System Report'),
+ 		    handler: function() {
+-			Proxmox.Utils.checked_command(function() { me.showReport(); });
++			me.showReport();
+ 		    },
+ 		},
+ 	    ],
+@@ -35145,7 +35145,7 @@
+ 	var version_btn = new Ext.Button({
+ 	    text: gettext('Package versions'),
+ 	    handler: function() {
+-		Proxmox.Utils.checked_command(function() { me.showVersions(); });
++		me.showVersions();
+ 	    },
+ 	});
+
+@@ -48409,7 +48409,6 @@
+ 		handler: function(data) {
+ 		    me.login = null;
+ 		    me.updateLoginData(data);
+-		    Proxmox.Utils.checked_command(Ext.emptyFn); // display subscription status
+ 		},
+ 	    });
+ 	}

--- a/vars/debian-bullseye.yml
+++ b/vars/debian-bullseye.yml
@@ -1,0 +1,4 @@
+---
+pve_release_key: proxmox-ve-release-6.x.asc
+pve_release_key_id: 7BF2812E8A6E88E0
+pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"


### PR DESCRIPTION
This commit add the two files needed to install new proxmox 7.x on Debian 11 bullseye.

I only tested a basic proxmox setup as stand alone system, therefore some more tweaks may be needed to get it up and running with all features.
