### PR TITLE
Fix regexp match on /etc/hosts for standalone nodes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,16 +81,16 @@
 - name: Define hostname in /etc/hosts for single-host installations
   lineinfile:
     dest: /etc/hosts
-    regexp: |-
-      {# Match an IPv4/v6 address at the start #}
-      ^\\h*[0-9a-f:.]+
-      {# Match at least one whitespace, and any non-hostname names #}
-      (\\h+.*)?\\h
-      {# Match either our fqdn or hostname #}
-      ({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }})
-      {# Require there be a word boundary at the end of the name(s). #}
-      {# This can be any whitespace, or end-of-line. #}
-      (\\h+.*|\\h*)$
+    regexp: "\
+      {# Match an IPv4/v6 address at the start #}\
+      ^\\s*[0-9a-f:.]+\
+      {# Match at least one whitespace, and any non-hostname names #}\
+      (\\s+.*)*\\s\
+      {# Match either our fqdn or hostname #}\
+      ({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }})\
+      {# Require there be a word boundary at the end of the name(s). #}\
+      {# This can be any whitespace, or end-of-line. #}\
+      (\\s+.*|\\s*)$"
     line: "{{ hostvars[inventory_hostname].pve_cluster_addr0 }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     backup: yes
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"


### PR DESCRIPTION
Update to #140.

After attempting to update an existing PVE install with latest develop, I noticed that the hosts file was being modified when it wasn't supposed to be. It turns out that the expression was rendering as follows:

```regex
^\\h*[0-9a-f:.]+
(\\h+.*)*\\h
(pve\.example\.host|pve)
(\\h+.*|\\h*)$
```

This PR updates it so that it renders as follows:

```regex
^\s*[0-9a-f:.]+(\s+.*)*\s (pve\.example\.host|host)(\s+.*|\s*)$
```

Newlines are removed (YAML really is annoying...), the broken escape is fixed and `\h` is replaced with `\s` as after some investigation it doesn't look like Python supports it (refer to `/usr/lib/pythonX.X/sre_parse.py`). The following exception was being thrown:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/re.py", line 252, in compile
    return _compile(pattern, flags)
  File "/usr/lib/python3.9/re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.9/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.9/sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib/python3.9/sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/usr/lib/python3.9/sre_parse.py", line 525, in _parse
    code = _escape(source, this, state)
  File "/usr/lib/python3.9/sre_parse.py", line 426, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
re.error: bad escape \h at position 1 (line 1, column 2)
```

I should note that even though the expression never matches, the `lineinfile` module apparently still processes the file for the exact `line` value and if it finds it, doesn't change it (and so this issue would've been hard to catch on a new installation).