### PR TITLE
Add Proxmox Backup Server storage type

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,8 +545,8 @@ Refer to `library/proxmox_role.py` [link][user-module] and
 
 You can use this role to manage storage within Proxmox VE (both in
 single server deployments and cluster deployments). For now, the only supported
-types are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool` and `btrfs`.
-Here are some examples.
+types are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool`, `btrfs`,
+and `pbs`. Here are some examples.
 
 ```
 pve_storages:
@@ -589,6 +589,13 @@ pve_storages:
       - 10.0.0.1
       - 10.0.0.2
       - 10.0.0.3
+  - name: pbs1
+    type: pbs
+    content: [ "backup" ]
+    server: 192.168.122.2
+    username: user@pbs
+    password: PBSPassword1
+    datastore: main
   - name: zfs1
     type: zfspool
     content: [ "images", "rootdir" ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -269,17 +269,23 @@
 - name: Configure Proxmox Storage
   proxmox_storage:
     name: "{{ item.name }}"
-    type: "{{ item.type }}"
-    disable: "{{ item.disable | default(False) }}"
-    path: "{{ item.path | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    # Globally applicable PVE API arguments
     content: "{{ item.content | default([]) }}"
+    disable: "{{ item.disable | default(False) }}"
     nodes: "{{ item.nodes | default(omit) }}"
+    type: "{{ item.type }}"
+    # Remaining PVE API arguments (depending on type) past this point
+    datastore: "{{ item.datastore | default(omit) }}"
+    encryption_key: "{{ item.encryption_key | default(omit) }}"
+    fingerprint: "{{ item.fingerprint | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
+    path: "{{ item.path | default(omit) }}"
     username: "{{ item.username | default(omit) }}"
     pool: "{{ item.pool | default(omit) }}"
     monhost: "{{ item.monhost | default(omit) }}"
     maxfiles: "{{ item.maxfiles | default(omit) }}"
     krbd: "{{ item.krbd | default(omit) }}"
-    state: "{{ item.state | default('present') }}"
     server: "{{ item.server | default(omit) }}"
     export: "{{ item.export | default(omit) }}"
     options: "{{ item.options | default(omit) }}"


### PR DESCRIPTION
Closes #163

Possibly some stuff missing, actually. I have some changes for `prune-backups` stashed currently because I need to write more parsing logic around it so I'm putting that off because it seems like it's optional (it's not mentioned in https://pve.proxmox.com/wiki/Storage:_Proxmox_Backup_Server) and applies to storages in general (so I'll work on it separately later). The `encryption-key` JSON might require further validation, but I have no idea what it's supposed to look like.

This isn't being added to the test environment since PVE apparently does try to contact PBS during creation and we obviously can't set up a test PBS instance just for this. However, I think that might only be if it's set to `autogen`? So maybe it'll skip contacting PBS if valid JSON is provided (and thus we could try to implement a test that way).