### PR TITLE
Ensure hosts with PVE already installed can join clusters

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,10 @@ Vagrant.configure("2") do |config|
   config.vm.box = "debian/bullseye64"
 
   config.vm.provider :libvirt do |libvirt|
-    libvirt.memory = 2048
+    libvirt.memory = 2560
     libvirt.cpus = 2
-    libvirt.storage :file, :size => '512M'
-    libvirt.storage :file, :size => '256M'
+    libvirt.storage :file, :size => '128M'
+    libvirt.storage :file, :size => '128M'
   end
 
   N = 3

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -1,16 +1,32 @@
 ---
-- name: Identify what host we're working with (inside outer loop)
-  set_fact:
-    _pve_current_node: "{{ item }}"
+- name: Identify the SSH public key and SSH addresses of initial cluster host
+  ansible.builtin.set_fact:
+    _pve_cluster_host_key: "{{ ' '.join((hostvars[groups[pve_group][0]]._pve_ssh_public_key.content | b64decode).split()[:-1]) }}"
+    _pve_cluster_host_addresses: "{{ hostvars[groups[pve_group][0]].pve_cluster_ssh_addrs | join(',') }}"
+
+- name: Temporarily mark that cluster host as known in root user's known_hosts
+  ansible.builtin.blockinfile:
+    dest: /root/.ssh/known_hosts
+    create: yes
+    mode: 0600
+    marker: "# {mark}: cluster host key for joining"
+    content: "{{ _pve_cluster_host_addresses }} {{ _pve_cluster_host_key }}"
 
 - name: Add node to Proxmox cluster
-  command: >-
+  ansible.builtin.command: >-
     pvecm add {{ hostvars[groups[pve_group][0]].pve_cluster_addr0 }} -use_ssh
     -link0 {{ pve_cluster_addr0 }}
     {% if pve_cluster_addr1 is defined %}
     -link1 {{ pve_cluster_addr1 }}
     {% endif %}
+  # Ensure that nodes join one-by-one because cluster joins create a lock
+  throttle: 1
   args:
     creates: "{{ pve_cluster_conf }}"
-  when:
-    - "inventory_hostname == _pve_current_node"
+
+- name: Remove the cluster host's public key from root user's known_hosts
+  ansible.builtin.blockinfile:
+    dest: /root/.ssh/known_hosts
+    state: absent
+    mode: 0600
+    marker: "# {mark}: cluster host key for joining"

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -60,7 +60,6 @@
     query: "response[?type=='cluster'].quorate | [0]"
 
 - include_tasks: pve_add_node.yml
-  with_items: "{{ groups[pve_group][1:] }}"
   when:
     - "_pve_active_cluster is not defined"
     - "inventory_hostname != groups[pve_group][0]"

--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -50,35 +50,10 @@
   notify:
     - reload sshd configuration
 
-- name: Fetch SSH public host keys
-  slurp:
-    src: "/etc/ssh/{{ item }}"
-  register: proxmox_ssh_public_host_keys
-  with_items:
-    - ssh_host_rsa_key.pub
-    - ssh_host_ed25519_key.pub
-    - ssh_host_ecdsa_key.pub
-
-- name: Check status of known hosts file
-  stat:
-    path: /etc/ssh/ssh_known_hosts
-  register: _pve_known_hosts_file
-
-- name: Add every host's host keys to global known_hosts
-  blockinfile:
-    dest: /etc/ssh/ssh_known_hosts
-    create: yes
-    mode: 0644
-    marker: "# {mark}: PVE host keys (managed by ansible)."
-    content: |
-      {% for host in groups[pve_group] %}
-      {% for _key_slurp in hostvars[host].proxmox_ssh_public_host_keys.results %}
-      {%- set _key = ' '.join((_key_slurp.content | b64decode).split()[:-1]) -%}
-      {{ hostvars[host].pve_cluster_ssh_addrs | join(",") }} {{ _key }}
-      {% endfor %}
-      {% endfor %}
-  when:
-    - "not (_pve_known_hosts_file.stat.islnk is defined and _pve_known_hosts_file.stat.islnk)"
+- name: Fetch a SSH public key to use for cluster joins
+  ansible.builtin.slurp:
+    src: "/etc/ssh/ssh_host_ed25519_key.pub"
+  register: _pve_ssh_public_key
 
 - name: Add PVE-provided ciphers to SSH client config
   lineinfile:


### PR DESCRIPTION
This revamps how we manage SSH `known_hosts` files with this role to only modify them during cluster joins. Given that PVE seems to manage this in the first place when a host is clustered (and we didn't touch it on hosts with PVE already installed), I believe this changeset shouldn't break anything and reduces our footprint on hosts.

Closes #138.