### PR TITLE
Fix reinstall of initialization node

### DIFF
--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -14,7 +14,7 @@
 
 - name: Add node to Proxmox cluster
   ansible.builtin.command: >-
-    pvecm add {{ hostvars[groups[pve_group][0]].pve_cluster_addr0 }} -use_ssh
+    pvecm add {{ hostvars[_init_node].pve_cluster_addr0 }} -use_ssh
     -link0 {{ pve_cluster_addr0 }}
     {% if pve_cluster_addr1 is defined %}
     -link1 {{ pve_cluster_addr1 }}

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -1,8 +1,8 @@
 ---
 - name: Identify the SSH public key and SSH addresses of initial cluster host
   ansible.builtin.set_fact:
-    _pve_cluster_host_key: "{{ ' '.join((hostvars[groups[pve_group][0]]._pve_ssh_public_key.content | b64decode).split()[:-1]) }}"
-    _pve_cluster_host_addresses: "{{ hostvars[groups[pve_group][0]].pve_cluster_ssh_addrs | join(',') }}"
+    _pve_cluster_host_key: "{{ ' '.join((hostvars[_init_node]._pve_ssh_public_key.content | b64decode).split()[:-1]) }}"
+    _pve_cluster_host_addresses: "{{ hostvars[_init_node].pve_cluster_ssh_addrs | join(',') }}"
 
 - name: Temporarily mark that cluster host as known in root user's known_hosts
   ansible.builtin.blockinfile:

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -38,6 +38,14 @@
   set_fact:
     _init_node: "{{ groups[pve_group][0] }}"
 
+- name: Find any active node in an already initialized Proxmox cluster
+  set_fact:
+    _init_node: "{{ item }}"
+  with_items: "{{ groups[pve_group] }}"
+  when:
+    - "'_pve_active_cluster' in hostvars[item]"
+    - "hostvars[item]['_pve_active_cluster'] == pve_cluster_clustername"
+
 - name: Initialize a Proxmox cluster
   command: >-
     pvecm create {{ pve_cluster_clustername }}
@@ -50,14 +58,6 @@
   when:
     - "_pve_found_clusters is not defined"
     - "inventory_hostname == _init_node"
-
-- name: Find any active node in an already initialized Proxmox cluster
-  set_fact:
-    _init_node: "{{ item }}"
-  with_items: "{{ groups[pve_group] }}"
-  when:
-    - "'_pve_active_cluster' in hostvars[item]"
-    - "hostvars[item]['_pve_active_cluster'] == pve_cluster_clustername"
 
 - name: Wait for quorum on initialization node
   proxmox_query:

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -35,11 +35,11 @@
   when: "(_pve_found_clusters | default([]) | length) == 1"
 
 - name: Default initialization node is the first node of pve_group
-  set_fact:
+  ansible.builtin.set_fact:
     _init_node: "{{ groups[pve_group][0] }}"
 
 - name: Find any active node in an already initialized Proxmox cluster
-  set_fact:
+  ansible.builtin.set_fact:
     _init_node: "{{ item }}"
   with_items: "{{ groups[pve_group] }}"
   when:
@@ -47,7 +47,7 @@
     - "hostvars[item]['_pve_active_cluster'] == pve_cluster_clustername"
 
 - name: Initialize a Proxmox cluster
-  command: >-
+  ansible.builtin.command: >-
     pvecm create {{ pve_cluster_clustername }}
     -link0 {{ pve_cluster_addr0 }}
     {% if pve_cluster_addr1 is defined %}

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -34,6 +34,10 @@
           cluster's name cannot be modified."
   when: "(_pve_found_clusters | default([]) | length) == 1"
 
+- name: Default initialization node is the first node of pve_group
+  set_fact:
+    _init_node: "{{ groups[pve_group][0] }}"
+
 - name: Initialize a Proxmox cluster
   command: >-
     pvecm create {{ pve_cluster_clustername }}
@@ -45,7 +49,15 @@
     creates: "{{ pve_cluster_conf }}"
   when:
     - "_pve_found_clusters is not defined"
-    - "inventory_hostname == groups[pve_group][0]"
+    - "inventory_hostname == _init_node"
+
+- name: Find any active node in an already initialized Proxmox cluster
+  set_fact:
+    _init_node: "{{ item }}"
+  with_items: "{{ groups[pve_group] }}"
+  when:
+    - "'_pve_active_cluster' in hostvars[item]"
+    - "hostvars[item]['_pve_active_cluster'] == pve_cluster_clustername"
 
 - name: Wait for quorum on initialization node
   proxmox_query:
@@ -55,14 +67,14 @@
   retries: 5
   delay: 5
   when:
-    - "inventory_hostname == groups[pve_group][0]"
+    - "inventory_hostname == _init_node"
   vars:
     query: "response[?type=='cluster'].quorate | [0]"
 
 - include_tasks: pve_add_node.yml
   when:
     - "_pve_active_cluster is not defined"
-    - "inventory_hostname != groups[pve_group][0]"
+    - "inventory_hostname != _init_node"
 
 - name: Check for PVE cluster HA groups
   proxmox_query:


### PR DESCRIPTION
Hello @lae,

First, thank you so much for this role, it is very helpful.

While running a disaster recovery scenario, we identified an issue with the role when we try to reinstall the first node of the cluster.

By default, the initialization node is the first node in the group
`pve_group`. When this node is reinstalled, it is not possible for the
role to wait for quorum on this node since it is not a member of the
cluster yet. Moreover, the tasks in pve_add_node.yml are not run for
this node.

Change the behavior of the role to pick any node already configured in
`pve_cluster_clustername` and use this one as an initialization node.

This does not change the behavior when installing a new cluster.

Without this change:
```
TASK [lae.proxmox : Wait for quorum on initialization node] ********************
skipping: [pve-3] => {"changed": false, "skip_reason": "Conditional result was False"}
skipping: [pve-2] => {"changed": false, "skip_reason": "Conditional result was False"}
FAILED - RETRYING: Wait for quorum on initialization node (5 retries left).
FAILED - RETRYING: Wait for quorum on initialization node (4 retries left).
FAILED - RETRYING: Wait for quorum on initialization node (3 retries left).
FAILED - RETRYING: Wait for quorum on initialization node (2 retries left).
FAILED - RETRYING: Wait for quorum on initialization node (1 retries left).
fatal: [pve-1]: FAILED! => {"attempts": 5, "changed": false, "response": [{"id": "node/pve-1", "ip": "192.168.121.234", "level": "", "local": 1, "name": "pve-1", "nodeid": 0, "online": 1, "type": "node"}]}

TASK [lae.proxmox : include_tasks] *********************************************
skipping: [pve-3] => (item=pve-3)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-3", "skip_reason": "Conditional result was False"}
skipping: [pve-3] => (item=pve-2)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-2", "skip_reason": "Conditional result was False"}
skipping: [pve-2] => (item=pve-3)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-3", "skip_reason": "Conditional result was False"}
skipping: [pve-2] => (item=pve-2)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-2", "skip_reason": "Conditional result was False"}
```

With this change:
```
TASK [lae.proxmox : Find any active node in an already initialized Proxmox cluster] ***
skipping: [pve-1] => (item=pve-1)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-1", "skip_reason": "Conditional result was False"}
skipping: [pve-3] => (item=pve-1)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-1", "skip_reason": "Conditional result was False"}
ok: [pve-1] => (item=pve-3) => {"ansible_facts": {"_init_node": "pve-3"}, "ansible_loop_var": "item", "changed": false, "item": "pve-3"}
skipping: [pve-2] => (item=pve-1)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-1", "skip_reason": "Conditional result was False"}
ok: [pve-3] => (item=pve-3) => {"ansible_facts": {"_init_node": "pve-3"}, "ansible_loop_var": "item", "changed": false, "item": "pve-3"}
ok: [pve-1] => (item=pve-2) => {"ansible_facts": {"_init_node": "pve-2"}, "ansible_loop_var": "item", "changed": false, "item": "pve-2"}
ok: [pve-2] => (item=pve-3) => {"ansible_facts": {"_init_node": "pve-3"}, "ansible_loop_var": "item", "changed": false, "item": "pve-3"}
ok: [pve-3] => (item=pve-2) => {"ansible_facts": {"_init_node": "pve-2"}, "ansible_loop_var": "item", "changed": false, "item": "pve-2"}
ok: [pve-2] => (item=pve-2) => {"ansible_facts": {"_init_node": "pve-2"}, "ansible_loop_var": "item", "changed": false, "item": "pve-2"}

TASK [lae.proxmox : Wait for quorum on initialization node] ********************
skipping: [pve-1] => {"changed": false, "skip_reason": "Conditional result was False"}
skipping: [pve-3] => {"changed": false, "skip_reason": "Conditional result was False"}
ok: [pve-2] => {"attempts": 1, "changed": false, "response": [{"id": "cluster", "name": "all", "nodes": 2, "quorate": 1, "type": "cluster", "version": 6}, {"id": "node/pve-2", "ip": "192.168.121.203", "level": "", "local": 1, "name": "pve-2", "nodeid": 3, "online": 1, "type": "node"}, {"id": "node/pve-3", "ip": "192.168.121.27", "level": "", "local": 0, "name": "pve-3", "nodeid": 2, "online": 1, "type": "node"}]}

TASK [lae.proxmox : include_tasks] *********************************************
skipping: [pve-3] => (item=pve-1)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-1", "skip_reason": "Conditional result was False"}
skipping: [pve-3] => (item=pve-3)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-3", "skip_reason": "Conditional result was False"}
skipping: [pve-2] => (item=pve-1)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-1", "skip_reason": "Conditional result was False"}
skipping: [pve-2] => (item=pve-3)  => {"ansible_loop_var": "item", "changed": false, "item": "pve-3", "skip_reason": "Conditional result was False"}
included: /home/bruno/.ansible/roles/lae.proxmox/tasks/pve_add_node.yml for pve-1 => (item=pve-1)
included: /home/bruno/.ansible/roles/lae.proxmox/tasks/pve_add_node.yml for pve-1 => (item=pve-3)

TASK [lae.proxmox : Identify what host we're working with (inside outer loop)] ***
ok: [pve-1] => {"ansible_facts": {"_pve_current_node": "pve-1"}, "changed": false}

TASK [lae.proxmox : Add node to Proxmox cluster] *******************************
changed: [pve-1] => {"changed": true, "cmd": ["pvecm", "add", "192.168.121.203", "-use_ssh", "-link0", "192.168.121.232"], "delta": "0:00:11.828450", "end": "2022-01-10 17:23:30.498590", "rc": 0, "start": "2022-01-10 17:23:18.670140", "stderr": "", "stderr_lines": [], "stdout": "copy corosync auth key\nstopping pve-cluster service\nbackup old database to '/var/lib/pve-cluster/backup/config-1641835400.sql.gz'\nwaiting for quorum...OK\n(re)generate node files\ngenerate new node certificate\nmerge authorized SSH keys and known hosts\ngenerated new node certificate, restart pveproxy and pvedaemon services\nsuccessfully added node 'pve-1' to cluster.", "stdout_lines": ["copy corosync auth key", "stopping pve-cluster service", "backup old database to '/var/lib/pve-cluster/backup/config-1641835400.sql.gz'", "waiting for quorum...OK", "(re)generate node files", "generate new node certificate", "merge authorized SSH keys and known hosts", "generated new node certificate, restart pveproxy and pvedaemon services", "successfully added node 'pve-1' to cluster."]}

```