### PR TITLE
Check for pve_manage_ssh in pve_add_node.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ joining the cluster, the PVE cluster needs to communicate once via SSH.
 would make to your SSH server config. This is useful if you use another role
 to manage your SSH server. Note that setting this to false is not officially
 supported, you're on your own to replicate the changes normally made in
-ssh_cluster_config.yml.
+`ssh_cluster_config.yml` and `pve_add_node.yml`.
 
 `interfaces_template` is set to the path of a template we'll use for configuring
 the network on these Debian machines. This is only necessary if you want to

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -1,16 +1,18 @@
 ---
-- name: Identify the SSH public key and SSH addresses of initial cluster host
-  ansible.builtin.set_fact:
-    _pve_cluster_host_key: "{{ ' '.join((hostvars[_init_node]._pve_ssh_public_key.content | b64decode).split()[:-1]) }}"
-    _pve_cluster_host_addresses: "{{ hostvars[_init_node].pve_cluster_ssh_addrs | join(',') }}"
+- block:
+  - name: Identify the SSH public key and SSH addresses of initial cluster host
+    ansible.builtin.set_fact:
+      _pve_cluster_host_key: "{{ ' '.join((hostvars[_init_node]._pve_ssh_public_key.content | b64decode).split()[:-1]) }}"
+      _pve_cluster_host_addresses: "{{ hostvars[_init_node].pve_cluster_ssh_addrs | join(',') }}"
 
-- name: Temporarily mark that cluster host as known in root user's known_hosts
-  ansible.builtin.blockinfile:
-    dest: /root/.ssh/known_hosts
-    create: yes
-    mode: 0600
-    marker: "# {mark}: cluster host key for joining"
-    content: "{{ _pve_cluster_host_addresses }} {{ _pve_cluster_host_key }}"
+  - name: Temporarily mark that cluster host as known in root user's known_hosts
+    ansible.builtin.blockinfile:
+      dest: /root/.ssh/known_hosts
+      create: yes
+      mode: 0600
+      marker: "# {mark}: cluster host key for joining"
+      content: "{{ _pve_cluster_host_addresses }} {{ _pve_cluster_host_key }}"
+  when: "pve_manage_ssh | bool"
 
 - name: Add node to Proxmox cluster
   ansible.builtin.command: >-
@@ -30,3 +32,4 @@
     state: absent
     mode: 0600
     marker: "# {mark}: cluster host key for joining"
+  when: "pve_manage_ssh | bool"


### PR DESCRIPTION
Recent changes in `develop` introduced a bug when `pve_manage_ssh: false`.

```
TASK [ansible-role-proxmox : Identify the SSH public key and SSH addresses of initial cluster host] *****************************************
fatal: [pve2]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'content'\n\nThe error appears to be in '/home/bruno/.ansible/roles/ansible-role-proxmox/tasks/pve_add_node.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Identify the SSH public key and SSH addresses of initial cluster host\n  ^ here\n"}
fatal: [pve3]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'content'\n\nThe error appears to be in '/home/bruno/.ansible/roles/ansible-role-proxmox/tasks/pve_add_node.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Identify the SSH public key and SSH addresses of initial cluster host\n  ^ here\n"}
```

This is because `hostvars[foo]._pve_ssh_public_key` is defined here:  https://github.com/lae/ansible-role-proxmox/blob/a8f5ad95322690510427629baaa91e1de48255d0/tasks/ssh_cluster_config.yml#L53-L56

This change updates `pve_add_node.yml` to avoid modifying SSH configuration when `pve_manage_ssh: false`.