### PR TITLE
Ignore module dirs that have no associated package

### DIFF
--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 import glob
-import re
 import subprocess
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
+
 
 def main():
     module = AnsibleModule(
@@ -33,22 +33,37 @@ def main():
         if subprocess.call(["dpkg", "--compare-versions", left, cmp_str, right]) == 0:
             latest_kernel = kernel
 
-    booted_kernel = "/lib/modules/{}".format(to_text(subprocess.check_output(["uname", "-r"]).strip))
+    booted_kernel = "/lib/modules/{}".format(to_text(
+            subprocess.run(["uname", "-r"], capture_output=True).stdout.strip))
 
     booted_kernel_package = ""
     old_kernel_packages = []
     if params['lookup_packages']:
         for kernel in kernels:
             # Identify the currently booted kernel and unused old kernels by
-            # querying which packages owns the directory in /lib/modules
+            # querying which packages own directories in /lib/modules
+            try:
+                sp = subprocess.run(["dpkg-query", "-S", kernel],
+                                    check=True, capture_output=True)
+            except subprocess.CalledProcessError as e:
+                # Ignore errors about directories not associated with a package
+                if e.stderr.startswith(b"dpkg-query: no path found matching"):
+                    continue
+                raise e
             if kernel.split("/")[-1] == booted_kernel.split("/")[-1]:
-                booted_kernel_package = to_text(subprocess.check_output(["dpkg-query", "-S", kernel])).split(":")[0]
+                booted_kernel_package = to_text(sp.stdout).split(":")[0]
             elif kernel != latest_kernel:
-                old_kernel_packages.append(to_text(subprocess.check_output(["dpkg-query", "-S", kernel])).split(":")[0])
+                old_kernel_packages.append(to_text(sp.stdout).split(":")[0])
 
     # returns True if we're not booted into the latest kernel
     new_kernel_exists = booted_kernel.split("/")[-1] != latest_kernel.split("/")[-1]
-    module.exit_json(changed=False, new_kernel_exists=new_kernel_exists, old_packages=old_kernel_packages, booted_package=booted_kernel_package)
+    module.exit_json(
+            changed=False,
+            new_kernel_exists=new_kernel_exists,
+            old_packages=old_kernel_packages,
+            booted_package=booted_kernel_package
+    )
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This fixes an edge case when there are directories in `/lib/modules` leftover by old packages (possibly, and maybe other reasons).

Failure example:

```
TASK [lae.proxmox : Collect kernel package information] ********************************************************************************************************************************************
fatal: [lilienne.is.also.aikatsu]: FAILED! => {"changed": false, "module_stderr": "Shared connection to lilienne.is.also.aikatsu closed.\r\n", "module_stdout": "\r\ndpkg-query: no path found matching pattern /lib/modules/5.10.0-11-amd64\r\nTraceback (most recent call last):\r\n  File \"/home/lae/.ansible/tmp/ansible-tmp-1646844430.0930457-570959-202055990360712/AnsiballZ_collect_kernel_info.py\", line 107, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/lae/.ansible/tmp/ansible-tmp-1646844430.0930457-570959-202055990360712/AnsiballZ_collect_kernel_info.py\", line 99, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/lae/.ansible/tmp/ansible-tmp-1646844430.0930457-570959-202055990360712/AnsiballZ_collect_kernel_info.py\", line 47, in invoke_module\r\n    runpy.run_module(mod_name='ansible.modules.collect_kernel_info', init_globals=dict(_module_fqn='ansible.modules.collect_kernel_info', _modlib_path=modlib_path),\r\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\r\n    _run_code(code, mod_globals, init_globals,\r\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_collect_kernel_info_payload_3ctojpb4/ansible_collect_kernel_info_payload.zip/ansible/modules/collect_kernel_info.py\", line 54, in <module>\r\n  File \"/tmp/ansible_collect_kernel_info_payload_3ctojpb4/ansible_collect_kernel_info_payload.zip/ansible/modules/collect_kernel_info.py\", line 47, in main\r\n  File \"/usr/lib/python3.9/subprocess.py\", line 424, in check_output\r\n    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,\r\n  File \"/usr/lib/python3.9/subprocess.py\", line 528, in run\r\n    raise CalledProcessError(retcode, process.args,\r\nsubprocess.CalledProcessError: Command '['dpkg-query', '-S', '/lib/modules/5.10.0-11-amd64']' returned non-zero exit status 1.\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

Directory situation:

```
lae@lilienne:~$ ls -l /lib/modules
total 125
drwxr-xr-x 3 root root 13 Feb 13 07:57 5.10.0-10-amd64
drwxr-xr-x 3 root root 13 Feb 13 07:57 5.10.0-11-amd64
drwxr-xr-x 5 root root 19 Dec 19 19:06 5.13.19-2-pve
drwxr-xr-x 5 root root 19 Feb 13 07:56 5.13.19-4-pve
drwxr-xr-x 5 root root 19 Mar  9 10:47 5.13.19-5-pve
-rw-r--r-- 1 root root 191344 Feb 13 07:56 vendor-reset.ko
lae@lilienne:~$ dpkg-query -S /lib/modules/5.10.0-10-amd64/
dpkg-query: no path found matching pattern /lib/modules/5.10.0-10-amd64/
lae@lilienne:~$ dpkg-query -S /lib/modules/5.10.0-11-amd64/
dpkg-query: no path found matching pattern /lib/modules/5.10.0-11-amd64/
```

Actually looking deeper into these folders, I guess they might've been left over from a DKMS module install.

```
~$ ls -laR /lib/modules/5.10.0-11-amd64
/lib/modules/5.10.0-11-amd64:
total 85
drwxr-xr-x 3 root root 13 Feb 13 07:57 .
drwxr-xr-x 7 root root  7 Mar  9 10:46 ..
-rw-r--r-- 1 root root 45 Feb 13 07:56 modules.alias
-rw-r--r-- 1 root root 12 Feb 13 07:56 modules.alias.bin
-rw-r--r-- 1 root root 12 Feb 13 07:56 modules.builtin.alias.bin
-rw-r--r-- 1 root root  0 Feb 13 07:56 modules.builtin.bin
-rw-r--r-- 1 root root 30 Feb 13 07:56 modules.dep
-rw-r--r-- 1 root root 68 Feb 13 07:56 modules.dep.bin
-rw-r--r-- 1 root root  0 Feb 13 07:56 modules.devname
-rw-r--r-- 1 root root 55 Feb 13 07:56 modules.softdep
-rw-r--r-- 1 root root 49 Feb 13 07:56 modules.symbols
-rw-r--r-- 1 root root 12 Feb 13 07:56 modules.symbols.bin
drwxr-xr-x 3 root root  3 Feb 13 07:56 updates

/lib/modules/5.10.0-11-amd64/updates:
total 43
drwxr-xr-x 3 root root  3 Feb 13 07:56 .
drwxr-xr-x 3 root root 13 Feb 13 07:57 ..
drwxr-xr-x 2 root root  3 Feb 13 07:56 dkms

/lib/modules/5.10.0-11-amd64/updates/dkms:
total 99
drwxr-xr-x 2 root root      3 Feb 13 07:56 .
drwxr-xr-x 3 root root      3 Feb 13 07:56 ..
-rw-r--r-- 1 root root 191344 Feb 13 07:56 vendor-reset.ko
```