### PR TITLE
Ensure ZFS modprobe configuration is inserted/removed correctly

### DIFF
--- a/tasks/kernel_module_cleanup.yml
+++ b/tasks/kernel_module_cleanup.yml
@@ -5,7 +5,7 @@
     state: absent
   when: >
     (pve_zfs_options is not defined) or
-    (pve_zfs_options is defined and not pve_zfs_options | bool) or
+    (pve_zfs_options is defined and not pve_zfs_options | length > 0) or
     (not pve_zfs_enabled | bool)
 
 - name: Disable loading of ZFS module on init

--- a/tasks/zfs.yml
+++ b/tasks/zfs.yml
@@ -17,7 +17,7 @@
     content: "options zfs {{ pve_zfs_options }}"
     dest: /etc/modprobe.d/zfs.conf
     mode: 0644
-  when: "pve_zfs_options is defined and pve_zfs_options | bool"
+  when: "pve_zfs_options is defined and pve_zfs_options | length > 0"
 
 - name: Configure email address for ZFS event daemon notifications
   lineinfile:


### PR DESCRIPTION
I noticed my ZFS modprobe configuration was disappearing a while back but wasn't sure how... 😅

I hadn't configured it via this role, but then noticed that it was being removed by the role. So I added a role variable, but it looks like it wasn't actually being configured, since the `bool` here is returning `false` when there's content inside of the role variable. We just want to check if it's not empty, I believe, so I changed it to use `length` instead.