### PR TITLE
Default to empty list when generating OSD list

### DIFF
--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -44,7 +44,7 @@
 
     - name: Generate a list of active OSDs
       ansible.builtin.set_fact:
-        _existing_ceph_osds: "{{ _ceph_volume_data.stdout | from_json | json_query('*[].devices[]') }}"
+        _existing_ceph_osds: "{{ _ceph_volume_data.stdout | from_json | json_query('*[].devices[]') | default([]) }}"
 
     - name: Generate list of unprovisioned OSDs
       ansible.builtin.set_fact:


### PR DESCRIPTION
On a fresh cluster/node with 0 already provisioned OSDs, this will
otherwise fail since _existing_ceph_osds will yield a non-iterable
object.