### PR TITLE
Default to IPv6 if host does not have IPv4

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@ pve_base_dir: "/etc/pve"
 pve_cluster_conf: "{{ pve_base_dir }}/corosync.conf"
 
 # defaults that need to be host facts
-_pve_cluster_addr0: "{{ ansible_default_ipv4.address }}"
+_pve_cluster_addr0: "{{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined else ansible_default_ipv6.address }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,4 +4,4 @@ pve_base_dir: "/etc/pve"
 pve_cluster_conf: "{{ pve_base_dir }}/corosync.conf"
 
 # defaults that need to be host facts
-_pve_cluster_addr0: "{{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined else ansible_default_ipv6.address }}"
+_pve_cluster_addr0: "{{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined else ansible_default_ipv6.address if ansible_default_ipv6.address is defined }}"


### PR DESCRIPTION
Otherwise on host with IPv6-only mgmt/corosync this will fail with error:

{{ ansible_default_ipv4.address }}: 'dict object' has no attribute 'address'