### PR TITLE
Fix parsing of dpkg-query for old kernel packages

### DIFF
--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -34,7 +34,7 @@ def main():
             latest_kernel = kernel
 
     booted_kernel = "/lib/modules/{}".format(to_text(
-            subprocess.run(["uname", "-r"], capture_output=True).stdout.strip))
+            subprocess.run(["uname", "-r"], capture_output=True).stdout).strip())
 
     booted_kernel_package = ""
     old_kernel_packages = []
@@ -50,10 +50,11 @@ def main():
                 if e.stderr.startswith(b"dpkg-query: no path found matching"):
                     continue
                 raise e
+            pkgs = to_text(sp.stdout).split(":")[0].split(", ")
             if kernel.split("/")[-1] == booted_kernel.split("/")[-1]:
-                booted_kernel_package = to_text(sp.stdout).split(":")[0]
+                booted_kernel_packages = pkgs
             elif kernel != latest_kernel:
-                old_kernel_packages.append(to_text(sp.stdout).split(":")[0])
+                old_kernel_packages.extend(pkgs)
 
     # returns True if we're not booted into the latest kernel
     new_kernel_exists = booted_kernel.split("/")[-1] != latest_kernel.split("/")[-1]
@@ -61,7 +62,7 @@ def main():
             changed=False,
             new_kernel_exists=new_kernel_exists,
             old_packages=old_kernel_packages,
-            booted_package=booted_kernel_package
+            booted_packages=booted_kernel_packages
     )
 
 


### PR DESCRIPTION
When looking for packages that own a directory in /lib/modules, it returns a comma-delimited list including both header and kernel packages. This properly separates them so that the purge step correctly uninstalls both packages, instead of a nonexistent package.