### PR TITLE
FIX new_kernel_exists in collect_kernel_info always returns true

### DIFF
--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -34,7 +34,7 @@ def main():
             latest_kernel = kernel
 
     booted_kernel = "/lib/modules/{}".format(to_text(
-            subprocess.run(["uname", "-r"], capture_output=True).stdout.strip))
+            subprocess.run(["uname", "-r"], capture_output=True).stdout.decode("utf-8").strip()))
 
     booted_kernel_package = ""
     old_kernel_packages = []


### PR DESCRIPTION
collect_kernel_info module reported kernel change(`new_kernel_exists` set to true) even in case when kernel did not change.