### PR TITLE
Fix host used to configure HA groups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -208,7 +208,7 @@
     state: "{{ item.state | default('present') }}"
     comment: "{{ item.comment | default(omit) }}"
   with_items: "{{ pve_pools }}"
-  when: "not pve_cluster_enabled or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Configure Proxmox roles
   proxmox_role:
@@ -216,7 +216,7 @@
     privileges: "{{ item.privileges }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ pve_roles }}"
-  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Configure Proxmox groups
   proxmox_group:
@@ -224,7 +224,7 @@
     state: "{{ item.state | default('present') }}"
     comment: "{{ item.comment | default(omit) }}"
   with_items: "{{ pve_groups }}"
-  when: "not pve_cluster_enabled or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Configure Proxmox user accounts
   proxmox_user:
@@ -239,7 +239,7 @@
     password: "{{ item.password | default(omit) }}"
     expire: "{{ item.expire | default(omit) }}"
   with_items: "{{ pve_users }}"
-  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Configure Proxmox ACLs
   proxmox_acl:
@@ -249,7 +249,7 @@
     groups: "{{ item.groups | default([]) }}"
     users: "{{ item.users | default([]) }}"
   with_items: "{{ pve_acls }}"
-  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Create ZFS Pools
   zfs:
@@ -287,7 +287,7 @@
     thinpool: "{{ item.thinpool | default(omit) }}"
     sparse: "{{ item.sparse | default(omit) }}"
   with_items: "{{ pve_storages }}"
-  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
   tags: storage
 
 - name: Check datacenter.cfg exists
@@ -295,7 +295,7 @@
     path: "/etc/pve/datacenter.cfg"
   register: _datacenter_cfg
   when:
-    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
     - "pve_datacenter_cfg | length > 0"
 
 - name: Create datacenter.cfg if it does not exist
@@ -304,7 +304,7 @@
     state: "touch"
     mode: 0640
   when:
-    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
     - "pve_datacenter_cfg | length > 0"
     - "not _datacenter_cfg.stat.exists"
 
@@ -319,7 +319,7 @@
       {{ k }}: {{ v }}
       {% endfor %}
   when:
-    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == groups[pve_group][0])"
+    - "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
     - "pve_datacenter_cfg | length > 0"
 
 - import_tasks: ssl_config.yml

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -80,7 +80,7 @@
   proxmox_query:
     query: "/cluster/ha/groups"
   register: _ha_group_list
-  when: "inventory_hostname == groups[pve_group][0]"
+  when: "inventory_hostname == _init_node"
 
 - name: Create PVE cluster HA groups
   command: >-
@@ -94,7 +94,7 @@
     -restricted {{ item.restricted }}
     {% endif %}
   when:
-    - "inventory_hostname == groups[pve_group][0]"
+    - "inventory_hostname == _init_node"
     - item.name not in _ha_group_list.response | json_query("[*].group")
   with_items: "{{ pve_cluster_ha_groups }}"
 
@@ -102,7 +102,7 @@
   command: >-
     ha-manager groupset {{ item.0.name }} -{{ item.1 }} "{{ item.0[item.1] }}"
   when:
-    - "inventory_hostname == groups[pve_group][0]"
+    - "inventory_hostname == _init_node"
     - item.0.name in _ha_group_list.response | json_query("[*].group")
     - item.1 in item.0
     - item.0[item.1] != _ha_group_list.response


### PR DESCRIPTION
When the role is run with `--limit nodes_without_first_node`, the HA groups are not configured (tasks are skipped). Use `_init_node` instead of `groups[pve_group][0]` to run the tasks.

`_init_node` is any active node in an already initialized Proxmox cluster which is part of the run.