### PR TITLE
fix: Replace deprecated ansible.netcommon.ipaddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS pack
 pve_zfs_create_volumes: [] # List of ZFS Volumes to create (to use as PVE Storages). See section on Storage Management.
 pve_ceph_enabled: false # Specifies wheter or not to install and configure Ceph packages. See below for an example configuration.
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-pacific bullseye main" # apt-repository configuration. Will be automatically set for 6.x and 7.x (Further information: https://pve.proxmox.com/wiki/Package_Repositories)
-pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}" # Ceph public network
+pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}" # Ceph public network
 # pve_ceph_cluster_network: "" # Optional, if the ceph cluster network is different from the public network (see https://pve.proxmox.com/pve-docs/chapter-pveceph.html#pve_ceph_install_wizard)
 pve_ceph_nodes: "{{ pve_group }}" # Host group containing all Ceph nodes
 pve_ceph_mon_group: "{{ pve_group }}" # Host group containing all Ceph monitor hosts
@@ -709,8 +709,9 @@ pve_ceph_fs:
     mountpoint: /srv/proxmox/backup
 ```
 
-`pve_ceph_network` by default uses the `ipaddr` filter, which requires the
-`netaddr` library to be installed and usable by your Ansible controller.
+`pve_ceph_network` by default uses the `ansible.utils.ipaddr` filter, which
+requires the `netaddr` library to be installed and usable by your Ansible
+controller.
 
 `pve_ceph_nodes` by default uses `pve_group`, this parameter allows to specify
 on which nodes install Ceph (e.g. if you don't want to install Ceph on all your

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ pve_zfs_enabled: no
 pve_zfs_create_volumes: []
 pve_ceph_enabled: false
 pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'buster' %}ceph-nautilus buster{% else %}ceph-quincy bullseye{% endif %} main"
-pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ipaddr('net') }}"
+pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"
 pve_ceph_nodes: "{{ pve_group }}"
 pve_ceph_mon_group: "{{ pve_group }}"
 pve_ceph_mgr_group: "{{ pve_ceph_mon_group }}"

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -241,7 +241,7 @@
     path: '{{ item.mountpoint }}'
     src: |-
       {% for h in groups[pve_ceph_mon_group] -%}
-      {{ hostvars[h].ansible_all_ipv4_addresses | ipaddr(pve_ceph_network) | first -}}
+      {{ hostvars[h].ansible_all_ipv4_addresses | ansible.utils.ipaddr(pve_ceph_network) | first -}}
       {{ loop.last | ternary("", ",") -}}
       {% endfor %}:/
     fstype: 'ceph'


### PR DESCRIPTION
This filter is deprecated as per https://docs.ansible.com/ansible/latest/collections/ansible/netcommon/ipaddr_filter.html

Use `ansible.utils.ipaddr` instead.

I observed the deprecation notice while adding new nodes to the cluster.
```
TASK [lae.proxmox : Mount Ceph filesystems] ************************************
Friday 31 May 2024  22:09:03 +0000 (0:00:00.299)       0:02:18.056 ************ 
[DEPRECATION WARNING]: Use 'ansible.utils.ipaddr' module instead. This feature 
will be removed from ansible.netcommon in a release after 2024-01-01. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```