### PR TITLE
pvesh: Fix invalid string escape sequences

### DIFF
--- a/module_utils/pvesh.py
+++ b/module_utils/pvesh.py
@@ -56,9 +56,9 @@ def run_command(handler, resource, **params):
 
         if handler == "get":
             if any(re.match(pattern, stderr[0]) for pattern in [
-                "^no such user \('.{3,64}?'\)$",
-                "^(group|role|pool) '[A-Za-z0-9\.\-_]+' does not exist$",
-                "^domain '[A-Za-z][A-Za-z0-9\.\-_]+' does not exist$"]):
+                r"^no such user \('.{3,64}?'\)$",
+                r"^(group|role|pool) '[A-Za-z0-9\.\-_]+' does not exist$",
+                r"^domain '[A-Za-z][A-Za-z0-9\.\-_]+' does not exist$"]):
                 return {u"status": 404, u"message": stderr[0]}
 
         # This will occur when a param is invalid


### PR DESCRIPTION
In Python, only a [limited set of characters][0] can be escaped with a backslash. In recent versions of Python, attempting to escape a non-escapeable character [raises a SyntaxWarning][1], polluting the playbook output with warnings like:

    <unknown>:59: SyntaxWarning: invalid escape sequence '\('
    <unknown>:60: SyntaxWarning: invalid escape sequence '\.'
    <unknown>:61: SyntaxWarning: invalid escape sequence '\.'

This commit adds the string literal prefix 'r' to regular expressions in pvesh.py to ensure that escape sequences are not interpreted in the given strings. As there were no valid escape sequences in those strings to begin with, the actual string content remains the same.

[0]: https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
[1]: https://github.com/python/cpython/issues/98401