### PR TITLE
fix: set noninteractive for apt upgarde

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,6 +147,8 @@
   retries: 2
   register: _dist_upgrade
   until: _dist_upgrade is succeeded
+  environment: 
+    - "DEBIAN_FRONTEND: noninteractive"
 
 - name: Perform system upgrades
   apt:


### PR DESCRIPTION
Hey,

I have a little fix here that fixes the `apt upgrade` not waiting for user input anymore.
Otherwise it can happen that during `apt upgarde` apt will ask user something and since these are not answered in ansible, an error is generated.

Regards
jeschero