### PR TITLE
Support for CIFS storages, namespacing in PBS, and ranking interfaces for corosync

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,7 @@ pve_users: [] # List of user definitions to manage in PVE. See section on User M
 pve_storages: [] # List of storages to manage in PVE. See section on Storage Management.
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
 pve_domains_cfg: [] # List of realms to use as authentication sources in the PVE domains.cfg config file.
-pve_no_log: false # Set this to true in production to disable logging for strorage add to avoid having credentials leaked in log.
-pve_addr0_priority: 255 # Type: integer Sets the Priority of the first Link for Corosync. Lower Number means higher Priority.
-pve_addr1_priority: 0 # Type: integer See [pvecm-network-priority] for more Information.
+pve_no_log: false # Set this to true in production to prevent leaking of storage credentials in run logs. (may be used in other tasks in the future)
 ```
 
 To enable clustering with this role, configure the following variables appropriately:
@@ -437,12 +435,17 @@ pve_manage_hosts_enabled : yes # Set this to no to NOT configure hosts file (cas
 
 The following variables are used to provide networking information to corosync.
 These are known as ring0_addr/ring1_addr or link0_addr/link1_addr, depending on
-PVE version. They should be IPv4 or IPv6 addresses. For more information, refer
-to the [Cluster Manager][pvecm-network] chapter in the PVE Documentation.
+PVE version. They should be IPv4 or IPv6 addresses. You can also configure the
+[priority of these interfaces][pvecm-network-priority] to hint to corosync
+which interface should handle cluster traffic (lower numbers indicate higher
+priority). For more information, refer to the [Cluster Manager][pvecm-network]
+chapter in the PVE Documentation.
 
 ```
 # pve_cluster_addr0: "{{ defaults to the default interface ipv4 or ipv6 if detected }}"
 # pve_cluster_addr1: "another interface's IP address or hostname"
+# pve_cluster_addr0_priority: 255
+# pve_cluster_addr1_priority: 0
 ```
 
 You can set options in the datacenter.cfg configuration file:
@@ -595,9 +598,9 @@ Refer to `library/proxmox_role.py` [link][user-module] and
 
 ## Storage Management
 
-You can use this role to manage storage within Proxmox VE (both in
-single server deployments and cluster deployments). For now, the only supported
-types are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool`, `btrfs`, `cifs`
+You can use this role to manage storage within Proxmox VE (both in single
+server deployments and cluster deployments). For now, the only supported types
+are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool`, `btrfs`, `cifs`
 and `pbs`. Here are some examples.
 
 ```

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ pve_users: [] # List of user definitions to manage in PVE. See section on User M
 pve_storages: [] # List of storages to manage in PVE. See section on Storage Management.
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
 pve_domains_cfg: [] # List of realms to use as authentication sources in the PVE domains.cfg config file.
+pve_no_log: false # Set this to true in production to disable logging for strorage add to avoid having credentials leaked in log.
 ```
 
 To enable clustering with this role, configure the following variables appropriately:

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ pve_storages: [] # List of storages to manage in PVE. See section on Storage Man
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
 pve_domains_cfg: [] # List of realms to use as authentication sources in the PVE domains.cfg config file.
 pve_no_log: false # Set this to true in production to disable logging for strorage add to avoid having credentials leaked in log.
+pve_addr0_priority: 255 # Type: integer Sets the Priority of the first Link for Corosync. Lower Number means higher Priority.
+pve_addr1_priority: 0 # Type: integer See [pvecm-network-priority] for more Information.
 ```
 
 To enable clustering with this role, configure the following variables appropriately:
@@ -595,7 +597,7 @@ Refer to `library/proxmox_role.py` [link][user-module] and
 
 You can use this role to manage storage within Proxmox VE (both in
 single server deployments and cluster deployments). For now, the only supported
-types are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool`, `btrfs`,
+types are `dir`, `rbd`, `nfs`, `cephfs`, `lvm`,`lvmthin`, `zfspool`, `btrfs`, `cifs`
 and `pbs`. Here are some examples.
 
 ```
@@ -646,6 +648,7 @@ pve_storages:
     username: user@pbs
     password: PBSPassword1
     datastore: main
+    namespace: Top/something # Optional
   - name: zfs1
     type: zfspool
     content: [ "images", "rootdir" ]
@@ -657,6 +660,15 @@ pve_storages:
     nodes: [ "lab-node01.local", "lab-node02.local" ]
     path: /mnt/proxmox_storage
     is_mountpoint: true
+  - name: cifs1
+    server: cifs-host.domain.tld
+    type: cifs
+    content: [ "snippets", "vztmpl", "iso" ]
+    share: sharename
+    subdir: /subdir
+    username: user
+    password: supersecurepass
+    domain: addomain.tld
 ```
 
 Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html for more information.
@@ -869,6 +881,7 @@ Adam Delo ([@ol3d](https://github.com/ol3d)) - PCIe Passthrough Support
 [pve-cluster]: https://pve.proxmox.com/wiki/Cluster_Manager
 [install-ansible]: http://docs.ansible.com/ansible/intro_installation.html
 [pvecm-network]: https://pve.proxmox.com/pve-docs/chapter-pvecm.html#_separate_cluster_network
+[pvecm-network-priority]: https://pve.proxmox.com/pve-docs/chapter-pvecm.html#_Corosync_Redundancy
 [pvesm]: https://pve.proxmox.com/pve-docs/chapter-pvesm.html
 [user-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_user.py
 [group-module]: https://github.com/lae/ansible-role-proxmox/blob/master/library/proxmox_group.py

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,8 @@ pve_cluster_clustername: "{{ pve_group }}"
 pve_manage_hosts_enabled: yes
 pve_cluster_addr0: "{{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined else ansible_default_ipv6.address if ansible_default_ipv6.address is defined }}"
 # pve_cluster_addr1: "{{ ansible_eth1.ipv4.address }}
+# pve_cluster_addr0_priority: 0
+# pve_cluster_addr1_priority: 1
 pve_datacenter_cfg: {}
 pve_domains_cfg: []
 pve_cluster_ha_groups: []
@@ -57,4 +59,4 @@ pve_storages: []
 pve_ssh_port: 22
 pve_manage_ssh: true
 pve_hooks: {}
-pve_no_logging: false
+pve_no_log: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,4 +57,4 @@ pve_storages: []
 pve_ssh_port: 22
 pve_manage_ssh: true
 pve_hooks: {}
-no_logging: false
+pve_no_logging: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,4 @@ pve_storages: []
 pve_ssh_port: 22
 pve_manage_ssh: true
 pve_hooks: {}
+no_logging: false

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -103,7 +103,22 @@ options:
         description:
             - Specifies whether or not the given path is an externally managed
             mountpoint.
-
+    namespace:
+        required: false
+        description:
+            - Specifies the Namespace that should be used on PBS
+    share:
+        required: false
+        description:
+            - Specifies the CIFS-Share to use
+    subdir:
+        required: false
+            - specifies the folder in the share dir to use for proxmox 
+              (useful to seperate proxmox content from other content)
+    domain:
+        required: false
+            - Specifies Realm to use for NTLM/LDAPS Authentification if using 
+              an AD-Enabled share
 author:
     - Fabien Brachere (@fbrachere)
 '''
@@ -170,6 +185,7 @@ EXAMPLES = '''
     datastore: main
     fingerprint: f2:fb:85:76:d2:2a:c4:96:5c:6e:d8:71:37:36:06:17:09:55:f7:04:e3:74:bb:aa:9e:26:85:92:63:c8:b9:23
     encryption_key: autogen
+    namespace: Top/something
 - name: Create a ZFS storage type
   proxmox_storage:
     name: zfs1
@@ -177,6 +193,17 @@ EXAMPLES = '''
     content: [ "images", "rootdir" ]
     pool: rpool/data
     sparse: true
+- name: CIFS-Share
+  proxmox_Storage:
+    name: cifs1
+    server: cifs-host.domain.tld
+    type: cifs
+    content: ["snippets", "vztmpl", "iso" ]
+    share: sharename
+    subdir: /subdir
+    username: user
+    password: supersecurepass
+    domain: addomain.tld
 '''
 
 RETURN = '''
@@ -220,7 +247,10 @@ class ProxmoxStorage(object):
         self.thinpool = module.params['thinpool']
         self.sparse = module.params['sparse']
         self.is_mountpoint = module.params['is_mountpoint']
-
+        self.namespace = module.params['namespace']
+        self.domain = module.params['domain']
+        self.subdir = module.params['subdir']
+        self.share = module.params['share']
         # Validate the parameters given to us
         fingerprint_re = re.compile('^([A-Fa-f0-9]{2}:){31}[A-Fa-f0-9]{2}$')
         if self.fingerprint is not None and not fingerprint_re.match(self.fingerprint):
@@ -305,16 +335,26 @@ class ProxmoxStorage(object):
             args['vgname'] = self.vgname
         if self.thinpool is not None:
             args['thinpool'] = self.thinpool
+        if self.namespace is not None:
+            args['namespace'] = self.namespace
         if self.sparse is not None:
             args['sparse'] = 1 if self.sparse else 0
         if self.is_mountpoint is not None:
             args['is_mountpoint'] = 1 if self.is_mountpoint else 0
-
+        if self.namespace is not None:
+            args['namespace'] = self.namespace
+        # CIFS
+        if self.subdir is not None:
+            args['subdir'] = self.subdir
+        if self.domain is not None:
+            args['domain'] = self.domain
+        # end cifs
         if self.maxfiles is not None and 'backup' not in self.content:
             self.module.fail_json(msg="maxfiles is not allowed when there is no 'backup' in content")
         if self.krbd is not None and self.type != 'rbd':
             self.module.fail_json(msg="krbd is only allowed with 'rbd' storage type")
-
+        if self.share is not None:
+            args['share'] = self.share
         return args
 
     def create_storage(self):
@@ -386,7 +426,7 @@ def main():
         nodes=dict(type='list', required=False, default=None),
         type=dict(default=None, type='str', required=True,
                   choices=["dir", "nfs", "rbd", "lvm", "lvmthin", "cephfs",
-                           "zfspool", "btrfs", "pbs"]),
+                           "zfspool", "btrfs", "pbs","cifs"]),
         # Remaining PVE API arguments (depending on type) past this point
         datastore=dict(default=None, type='str', required=False),
         encryption_key=dict(default=None, type='str', required=False),
@@ -405,7 +445,12 @@ def main():
         vgname=dict(default=None, type='str', required=False),
         thinpool=dict(default=None, type='str', required=False),
         sparse=dict(default=None, type='bool', required=False),
-        is_mountpoint=dict(default=None, type='bool', required=False),
+        is_mountpoint=dict(default=None, type='bool', required=False),        
+        namespace=dict(default=None, type='str', required=False),
+        subdir=dict(default=None, type='str', required=False),
+        domain=dict(default=None, type='str', required=False),
+        share=dict(default=None, type='str', required=False),
+
     )
 
     module = AnsibleModule(
@@ -420,7 +465,8 @@ def main():
             ["type", "lvmthin", ["vgname", "thinpool", "content"]],
             ["type", "zfspool", ["pool", "content"]],
             ["type", "btrfs", ["path", "content"]],
-            ["type", "pbs", ["server", "username", "password", "datastore"]]
+            ["type", "pbs", ["server", "username", "password", "datastore"]],
+            ["type", "cifs", ["server", "share"]],
         ],
         required_by={
             "master_pubkey": "encryption_key"

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -113,12 +113,13 @@ options:
             - Specifies the CIFS-Share to use
     subdir:
         required: false
-            - specifies the folder in the share dir to use for proxmox 
+            - specifies the folder in the share dir to use for proxmox
               (useful to seperate proxmox content from other content)
     domain:
         required: false
-            - Specifies Realm to use for NTLM/LDAPS Authentification if using 
+            - Specifies Realm to use for NTLM/LDAPS Authentification if using
               an AD-Enabled share
+
 author:
     - Fabien Brachere (@fbrachere)
 '''
@@ -247,10 +248,10 @@ class ProxmoxStorage(object):
         self.thinpool = module.params['thinpool']
         self.sparse = module.params['sparse']
         self.is_mountpoint = module.params['is_mountpoint']
-        
+
         # namespace for pbs
         self.namespace = module.params['namespace']
-        # new params for cifs
+        # CIFS properties
         self.domain = module.params['domain']
         self.subdir = module.params['subdir']
         self.share = module.params['share']
@@ -449,7 +450,7 @@ def main():
         vgname=dict(default=None, type='str', required=False),
         thinpool=dict(default=None, type='str', required=False),
         sparse=dict(default=None, type='bool', required=False),
-        is_mountpoint=dict(default=None, type='bool', required=False),        
+        is_mountpoint=dict(default=None, type='bool', required=False),
         namespace=dict(default=None, type='str', required=False),
         subdir=dict(default=None, type='str', required=False),
         domain=dict(default=None, type='str', required=False),

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -194,11 +194,11 @@ EXAMPLES = '''
     pool: rpool/data
     sparse: true
 - name: CIFS-Share
-  proxmox_Storage:
+  proxmox_storage:
     name: cifs1
     server: cifs-host.domain.tld
     type: cifs
-    content: ["snippets", "vztmpl", "iso" ]
+    content: [ "snippets", "vztmpl", "iso" ]
     share: sharename
     subdir: /subdir
     username: user
@@ -251,6 +251,7 @@ class ProxmoxStorage(object):
         self.domain = module.params['domain']
         self.subdir = module.params['subdir']
         self.share = module.params['share']
+
         # Validate the parameters given to us
         fingerprint_re = re.compile('^([A-Fa-f0-9]{2}:){31}[A-Fa-f0-9]{2}$')
         if self.fingerprint is not None and not fingerprint_re.match(self.fingerprint):
@@ -355,6 +356,7 @@ class ProxmoxStorage(object):
             self.module.fail_json(msg="krbd is only allowed with 'rbd' storage type")
         if self.share is not None:
             args['share'] = self.share
+
         return args
 
     def create_storage(self):
@@ -426,7 +428,7 @@ def main():
         nodes=dict(type='list', required=False, default=None),
         type=dict(default=None, type='str', required=True,
                   choices=["dir", "nfs", "rbd", "lvm", "lvmthin", "cephfs",
-                           "zfspool", "btrfs", "pbs","cifs"]),
+                           "zfspool", "btrfs", "pbs", "cifs"]),
         # Remaining PVE API arguments (depending on type) past this point
         datastore=dict(default=None, type='str', required=False),
         encryption_key=dict(default=None, type='str', required=False),
@@ -450,7 +452,6 @@ def main():
         subdir=dict(default=None, type='str', required=False),
         domain=dict(default=None, type='str', required=False),
         share=dict(default=None, type='str', required=False),
-
     )
 
     module = AnsibleModule(

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -247,7 +247,10 @@ class ProxmoxStorage(object):
         self.thinpool = module.params['thinpool']
         self.sparse = module.params['sparse']
         self.is_mountpoint = module.params['is_mountpoint']
+        
+        # namespace for pbs
         self.namespace = module.params['namespace']
+        # new params for cifs
         self.domain = module.params['domain']
         self.subdir = module.params['subdir']
         self.share = module.params['share']
@@ -342,20 +345,19 @@ class ProxmoxStorage(object):
             args['sparse'] = 1 if self.sparse else 0
         if self.is_mountpoint is not None:
             args['is_mountpoint'] = 1 if self.is_mountpoint else 0
-        if self.namespace is not None:
-            args['namespace'] = self.namespace
+
         # CIFS
         if self.subdir is not None:
             args['subdir'] = self.subdir
         if self.domain is not None:
             args['domain'] = self.domain
+        if self.share is not None:
+            args['share'] = self.share
         # end cifs
         if self.maxfiles is not None and 'backup' not in self.content:
             self.module.fail_json(msg="maxfiles is not allowed when there is no 'backup' in content")
         if self.krbd is not None and self.type != 'rbd':
             self.module.fail_json(msg="krbd is only allowed with 'rbd' storage type")
-        if self.share is not None:
-            args['share'] = self.share
 
         return args
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -337,7 +337,7 @@
     domain: "{{ item.domain | default(omit) }}"
     subdir: "{{ item.subdir | default(omit) }}"
     share: "{{ item.share | default(omit) }}"
-  no_log: "{{ pve_no_logging }}"
+  no_log: "{{ pve_no_log }}"
   with_items: "{{ pve_storages }}"
   when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
   tags: storage

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -333,6 +333,12 @@
     vgname: "{{ item.vgname | default(omit) }}"
     thinpool: "{{ item.thinpool | default(omit) }}"
     sparse: "{{ item.sparse | default(omit) }}"
+    namespace: "{{ item.namespace | default(omit) }}"
+    domain: "{{ item.domain | default(omit) }}"
+    subdir: "{{ item.subdir | default(omit) }}"
+    share: "{{ item.share | default(omit) }}"
+# Set logging to true in production in ypur groupvars  
+  no_log: "{{ no_logging | default(false) }}"
   with_items: "{{ pve_storages }}"
   when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
   tags: storage

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -337,8 +337,7 @@
     domain: "{{ item.domain | default(omit) }}"
     subdir: "{{ item.subdir | default(omit) }}"
     share: "{{ item.share | default(omit) }}"
-# Set logging to true in production in ypur groupvars  
-  no_log: "{{ no_logging | default(false) }}"
+  no_log: "{{ pve_no_logging }}"
   with_items: "{{ pve_storages }}"
   when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
   tags: storage

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -17,9 +17,9 @@
 - name: Add node to Proxmox cluster
   ansible.builtin.command: >-
     pvecm add {{ hostvars[_init_node].pve_cluster_addr0 }} -use_ssh
-    -link0 {{ pve_cluster_addr0 }},priority={% if pve_cluster_addr0_priority is defined %},priority={{ pve_cluster_addr0_priority }}{% endif %}
+    -link0 {{ pve_cluster_addr0 }}{% if pve_cluster_addr0_priority is defined %},priority={{ pve_cluster_addr0_priority }}{% endif %}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }},priority={% if pve_cluster_addr1_priority is defined %},priority={{ pve_cluster_addr1_priority }}{% endif %}
+    -link1 {{ pve_cluster_addr1 }}{% if pve_cluster_addr1_priority is defined %},priority={{ pve_cluster_addr1_priority }}{% endif %}
     {% endif %}
   # Ensure that nodes join one-by-one because cluster joins create a lock
   throttle: 1

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -17,9 +17,9 @@
 - name: Add node to Proxmox cluster
   ansible.builtin.command: >-
     pvecm add {{ hostvars[_init_node].pve_cluster_addr0 }} -use_ssh
-    -link0 {{ pve_cluster_addr0 }}
+    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_prio0 | default(omit)}}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }}
+    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_prio1 | default(omit)}}
     {% endif %}
   # Ensure that nodes join one-by-one because cluster joins create a lock
   throttle: 1

--- a/tasks/pve_add_node.yml
+++ b/tasks/pve_add_node.yml
@@ -17,9 +17,9 @@
 - name: Add node to Proxmox cluster
   ansible.builtin.command: >-
     pvecm add {{ hostvars[_init_node].pve_cluster_addr0 }} -use_ssh
-    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_prio0 | default(omit)}}
+    -link0 {{ pve_cluster_addr0 }},priority={% if pve_cluster_addr0_priority is defined %},priority={{ pve_cluster_addr0_priority }}{% endif %}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_prio1 | default(omit)}}
+    -link1 {{ pve_cluster_addr1 }},priority={% if pve_cluster_addr1_priority is defined %},priority={{ pve_cluster_addr1_priority }}{% endif %}
     {% endif %}
   # Ensure that nodes join one-by-one because cluster joins create a lock
   throttle: 1

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -49,9 +49,9 @@
 - name: Initialize a Proxmox cluster
   ansible.builtin.command: >-
     pvecm create {{ pve_cluster_clustername }}
-    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_addr0_priority | default(0)}}
+    -link0 {{ pve_cluster_addr0 }}{% if pve_cluster_addr0_priority is defined %},priority={{ pve_cluster_addr0_priority }}{% endif %}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_addr1_priority | default(1)}}
+    -link1 {{ pve_cluster_addr1 }}{% if pve_cluster_addr1_priority is defined %},priority={{ pve_cluster_addr1_priority }}{% endif %}
     {% endif %}
   args:
     creates: "{{ pve_cluster_conf }}"

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -49,9 +49,9 @@
 - name: Initialize a Proxmox cluster
   ansible.builtin.command: >-
     pvecm create {{ pve_cluster_clustername }}
-    -link0 {{ pve_cluster_addr0 }}
+    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_prio0 | default(omit)}}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }}
+    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_prio1 | default(omit)}}
     {% endif %}
   args:
     creates: "{{ pve_cluster_conf }}"

--- a/tasks/pve_cluster_config.yml
+++ b/tasks/pve_cluster_config.yml
@@ -49,9 +49,9 @@
 - name: Initialize a Proxmox cluster
   ansible.builtin.command: >-
     pvecm create {{ pve_cluster_clustername }}
-    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_prio0 | default(omit)}}
+    -link0 {{ pve_cluster_addr0 }},priority={{ pve_cluster_addr0_priority | default(0)}}
     {% if pve_cluster_addr1 is defined %}
-    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_prio1 | default(omit)}}
+    -link1 {{ pve_cluster_addr1 }},priority={{ pve_cluster_addr1_priority | default(1)}}
     {% endif %}
   args:
     creates: "{{ pve_cluster_conf }}"


### PR DESCRIPTION
I added CIFS support and the new feature from pbs for namespaces so that it is possible to mount pbs namespaces with pve_cluster_prio0 and pve_cluster_prio1 it is possible to define which link has the higher priority. 