### PR TITLE
Metric Servers management in Proxmox

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ Then system interrupt remapping is supported and you do not need to enable unsaf
 
 ## Metrics Server Configuration
 
-You can configure metric servers in Proxmox VE using the `proxmox_metric_server` module. Below is an example configuration for different types of metric servers:
+You can configure metric servers in Proxmox VE using the `pve_metric_servers` role variable. Below is an example configuration for different types of metric servers:
 
 ```yaml
 pve_metric_servers:
@@ -853,7 +853,6 @@ pve_metric_servers:
     organization: myorg
     bucket: mybucket
     token: mytoken
-    disable: false
     timeout: 30
     max_body_size: 25000000
     verify_certificate: true
@@ -863,7 +862,6 @@ pve_metric_servers:
     type: graphite
     protocol: tcp
     path: mygraphitepath
-    disable: false
     mtu: 1500
 ```
 
@@ -884,25 +882,6 @@ pve_metric_servers:
 - `max_body_size`: (optional) Maximum body size in bytes. Available only for influxdb with the http v2 API. Default is `25000000`.
 - `mtu`: (optional) MTU for UDP metric transmission.
 - `verify_certificate`: (optional) Verify SSL certificate. Available only for influxdb with https.
-
-### Example Configuration
-
-Here is an example configuration to create a new InfluxDB metric server:
-
-```yaml
-- name: Create a new InfluxDB metric server
-  proxmox_metric_server:
-    id: "influxdb"
-    port: 8086
-    server: "influxdb.example.com"
-    type: "influxdb"
-    protocol: "http"
-    organization: "myorg"
-    bucket: "mybucket"
-    token: "mytoken"
-```
-
-For more information, refer to the Proxmox VE API documentation: [Proxmox VE API Viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/cluster/metrics/server/{id}).
 
 ## Developer Notes
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ of the `ops` group. Read the **User and ACL Management** section for more info.
 The backend needs to be supported by [Proxmox][pvesm]. Read the **Storage
 Management** section for more info.
 
+`pve_metric_servers` allows you to configure a metric server for the PVE cluster.
+This is useful if you want to use InfluxDB, Graphite or other (with telegraf).
+
 `pve_ssh_port` allows you to change the SSH port. If your SSH is listening on
 a port other than the default 22, please set this variable. If a new node is
 joining the cluster, the PVE cluster needs to communicate once via SSH.
@@ -420,6 +423,7 @@ pve_roles: [] # Added more roles with specific privileges. See section on User M
 pve_groups: [] # List of group definitions to manage in PVE. See section on User Management.
 pve_users: [] # List of user definitions to manage in PVE. See section on User Management.
 pve_storages: [] # List of storages to manage in PVE. See section on Storage Management.
+pve_metric_servers: [] # List of metric servers to configure in PVE.
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
 pve_domains_cfg: [] # List of realms to use as authentication sources in the PVE domains.cfg config file.
 pve_no_log: false # Set this to true in production to prevent leaking of storage credentials in run logs. (may be used in other tasks in the future)
@@ -834,6 +838,71 @@ Then system interrupt remapping is supported and you do not need to enable unsaf
 `pve_pcie_ignore_msrs` prevents some Windows applications like GeForce Experience, Passmark Performance Test and SiSoftware Sandra from crashing the VM. This value is only required when passing PCI devices to Windows based systems.
 
 `pve_pcie_report_msrs` can be used to enable or disable logging messages of msrs warnings. If you see a lot of warning messages in your 'dmesg' system log, this value can be used to silence msrs warnings.
+
+## Metrics Server Configuration
+
+You can configure metric servers in Proxmox VE using the `proxmox_metric_server` module. Below is an example configuration for different types of metric servers:
+
+```yaml
+pve_metric_servers:
+  - id: influxdb1
+    port: 8086
+    server: influxdb.example.com
+    type: influxdb
+    protocol: http
+    organization: myorg
+    bucket: mybucket
+    token: mytoken
+    disable: false
+    timeout: 30
+    max_body_size: 25000000
+    verify_certificate: true
+  - id: graphite1
+    port: 2003
+    server: graphite.example.com
+    type: graphite
+    protocol: tcp
+    path: mygraphitepath
+    disable: false
+    mtu: 1500
+```
+
+### Configuration Variables
+
+- `id`: (required) Unique identifier for the metric server.
+- `port`: (optional) Port of the metric server. Default is `8089`.
+- `server`: (required) DNS name or IP address of the metric server.
+- `type`: (optional) Type of metric server. Possible values: `influxdb`, `graphite`. Default is `influxdb`.
+- `protocol`: (optional) Protocol used to send metrics. Possible values: `udp`, `tcp`, `http`, `https`. Default is `udp`.
+- `disable`: (optional) Disable the metric server. Default is `false`.
+- `organization`: (optional) Organization name. Available only for influxdb with the http v2 API.
+- `bucket`: (optional) Bucket name for influxdb. Useful only with the http v2 API or compatible.
+- `token`: (optional) InfluxDB access token. Required only when using the http v2 API.
+- `path`: (optional) Graphite root path. Available only for graphite.
+- `api_path_prefix`: (optional) API path prefix inserted between `<host>:<port>/` and `/api2/`. Useful if the InfluxDB service is running behind a reverse proxy. Available only for influxdb with the http v2 API.
+- `timeout`: (optional) Timeout in seconds. Available only for influxdb with the http v2 API or Graphite TCP socket.
+- `max_body_size`: (optional) Maximum body size in bytes. Available only for influxdb with the http v2 API. Default is `25000000`.
+- `mtu`: (optional) MTU for UDP metric transmission.
+- `verify_certificate`: (optional) Verify SSL certificate. Available only for influxdb with https.
+
+### Example Configuration
+
+Here is an example configuration to create a new InfluxDB metric server:
+
+```yaml
+- name: Create a new InfluxDB metric server
+  proxmox_metric_server:
+    id: "influxdb"
+    port: 8086
+    server: "influxdb.example.com"
+    type: "influxdb"
+    protocol: "http"
+    organization: "myorg"
+    bucket: "mybucket"
+    token: "mytoken"
+```
+
+For more information, refer to the Proxmox VE API documentation: [Proxmox VE API Viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/cluster/metrics/server/{id}).
 
 ## Developer Notes
 

--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ John Marion ([@jmariondev](https://github.com/jmariondev))
 foerkede ([@foerkede](https://github.com/foerkede)) - ZFS storage support  
 Guiffo Joel ([@futuriste](https://github.com/futuriste)) - Pool configuration support  
 Adam Delo ([@ol3d](https://github.com/ol3d)) - PCIe Passthrough Support
+Antoine Thys ([@thystips](https://github.com/thystips)) - Metric Servers Support
 
 [Full list of contributors](https://github.com/lae/ansible-role-proxmox/graphs/contributors)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ pve_groups: []
 pve_users: []
 pve_acls: []
 pve_storages: []
+pve_metric_servers: []
 pve_ssh_port: 22
 pve_manage_ssh: true
 pve_hooks: {}

--- a/library/proxmox_metric_server.py
+++ b/library/proxmox_metric_server.py
@@ -1,0 +1,411 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {
+    "metadata_version": "0.1",
+    "status": ["preview"],
+    "supported_by": "thystips",
+}
+
+DOCUMENTATION = """
+---
+module: proxmox_metric_server
+short_description: Manages the Metric Server in Proxmox
+options:
+    id:
+        required: true
+        type: str
+        description:
+            - ID of the server.
+    port:
+        type: int
+        default: 8089
+        description:
+            - Port of the server.
+    server:
+        required: true
+        type: str
+        description:
+            - Server dns name or IP address.
+    type:
+        type: str
+        default: "influxdb"
+        choices: [ "influxdb", "graphite" ]
+        description:
+            - Plugin type.
+    protocol:
+        type: str
+        default: "udp"
+        choices: [ "udp", "tcp", "http", "https" ]
+        description:
+            - Protocol used to send metrics.
+            - "http" and "https" are only available for "influxdb" type and using http v2 api.
+            - "tcp" is only available for "graphite" type.
+    disable:
+        type: bool
+        default: false
+        description:
+            - Disable the metric server.
+    organization:
+        type: str
+        description:
+            - Organization name.
+            - Only available for "influxdb" with http v2 api.
+    bucket:
+        type: str
+        description:
+            - Bucket name for "influxdb" type.
+            - Only useful with http v2 api or compatible.
+    token:
+        type: str
+        description:
+            - The InfluxDB access token.
+            - Only necessary when using the http v2 api.
+            - If the v2 compatibility api is used, use 'user:password' instead.
+    path:
+        type: str
+        description:
+            - Root Graphite path.
+            - Only available for "graphite" type.
+    api_path_prefix:
+        type: str
+        description:
+            - An API path prefix inserted between '<host>:<port>/' and '/api2/'.
+            - Can be useful if the InfluxDB service runs behind a reverse proxy.
+            - Only available for "influxdb" with http v2 api.
+    timeout:
+        type: int
+        description:
+            - Timeout in seconds.
+            - Only available for "influxdb" with http v2 api or Graphite TCP socket.
+    max_body_size:
+        type: bytes
+        default: 25000000
+        description:
+            - Maximum body size in bytes.
+            - Only available for "influxdb" with http v2 api.
+    mtu:
+        type: int
+        description:
+            - MTU for UDP metrics transmission.
+    verify_certificate:
+        type: bool
+        description:
+            - Verify the SSL certificate.
+            - Only available for "influxdb" with https.
+    state:
+        type: str
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Whether the server should exist or not.
+
+author:
+    - ThysTips (@thystips)
+"""
+
+EXAMPLES = """
+- name: Create a new InfluxDB metric server
+  proxmox_metric_server:
+    id: "influxdb"
+    port: 8086
+    server: "influxdb.example.com"
+    type: "influxdb"
+    protocol: "http"
+    organization: "myorg"
+    bucket: "mybucket"
+    token: "mytoken"
+"""
+
+RETURN = """
+"""
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+from ansible.module_utils._text import to_text  # noqa: E402, F401
+from ansible_collections.weytop.vmfarm.plugins.module_utils.pvesh import ProxmoxShellError # type: ignore # noqa: E402
+import ansible_collections.weytop.vmfarm.plugins.module_utils.pvesh as pvesh # type: ignore # noqa: E402
+
+class ProxmoxMetricServer(object):
+    def __init__(self, module):
+        self.module = module
+        self.id = module.params["id"]
+        self.port = module.params["port"]
+        self.server = module.params["server"]
+        self.type = module.params["type"]
+        self.protocol = module.params["protocol"]
+        self.disable = module.params["disable"]
+        self.organization = module.params["organization"]
+        self.bucket = module.params["bucket"]
+        self.token = module.params["token"]
+        self.path = module.params["path"]
+        self.api_path_prefix = module.params["api_path_prefix"]
+        self.timeout = module.params["timeout"]
+        self.max_body_size = module.params["max_body_size"]
+        self.mtu = module.params["mtu"]
+        self.verify_certificate = module.params["verify_certificate"]
+        self.state = module.params["state"]
+
+        try:
+            self.existing_server = pvesh.get("cluster/metrics/server")
+        except ProxmoxShellError as e:
+            self.module.fail_json(msg=e.message, status_code=e.status_code)
+
+        self.parse_servers()
+
+    def parse_servers(self):
+        self.servers = []
+        for existing_server in self.existing_server: # type: ignore
+            self.servers.append(existing_server.get("id"))
+
+    def lookup(self):
+        self.servers = []
+        for existing_server in self.existing_server: # type: ignore
+            if existing_server.get("id") == self.id:
+                args = {}
+                args["id"] = existing_server.get("id")
+                return args
+
+        return None
+
+    def exists(self):
+        if self.id not in self.servers:
+            return False
+
+        return True
+
+    def prepare_server_args(self, create=True):
+        args = {}
+
+        args["port"] = self.port
+        args["server"] = self.server
+        if create:
+            args["type"] = self.type
+        if self.protocol is not None:
+            args["influxdbproto" if self.type == "influxdb" else "proto"] = self.protocol
+        args["disable"] = int(self.disable)
+        if self.organization is not None:
+            args["organization"] = self.organization
+        if self.bucket is not None:
+            args["bucket"] = self.bucket
+        if self.token is not None:
+            args["token"] = self.token
+        if self.path is not None:
+            args["path"] = self.path
+        if self.api_path_prefix is not None:
+            args["api-path-prefix"] = self.api_path_prefix
+        if self.timeout is not None:
+            args["timeout"] = self.timeout
+        if self.max_body_size is not None:
+            args["max-body-size"] = self.max_body_size
+        if self.mtu is not None:
+            args["mtu"] = self.mtu
+        if self.verify_certificate is not None:
+            args["verify-certificate"] = int(self.verify_certificate)
+
+        return args
+
+    def remove_server(self):
+        try:
+            pvesh.delete("cluster/metrics/server/{}".format(self.id))
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def create_server(self):
+        new_server = self.prepare_server_args()
+
+        try:
+            pvesh.create("cluster/metrics/server/{}".format(self.id), **new_server)
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def modify_server(self):
+        existing_server = self.lookup()
+        modified_server = self.prepare_server_args(create=False)
+        updated_fields = []
+        error = None
+
+        for key in modified_server:
+            if key not in existing_server:
+                updated_fields.append(key)
+            else:
+                new_value = modified_server.get(key)
+                old_value = existing_server.get(key) # type: ignore
+                if isinstance(old_value, list):
+                    old_value = ",".join(sorted(old_value))
+                if isinstance(new_value, list):
+                    new_value = ",".join(sorted(new_value))
+
+                if new_value != old_value:
+                    updated_fields.append(key)
+
+        if self.module.check_mode:
+            self.module.exit_json(
+                changed=bool(updated_fields), expected_changes=updated_fields
+            )
+
+        if not updated_fields:
+            # No changes necessary
+            return (updated_fields, error)
+
+        try:
+            pvesh.set("cluster/metrics/server/{}".format(self.id), **modified_server)
+        except ProxmoxShellError as e:
+            error = e.message
+
+        return (updated_fields, error)
+
+
+def main():
+    # Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html#/cluster/metrics/server/{id}
+    module_args = dict(
+        id=dict(type="str", required=True),
+        port=dict(type="int", default=8089),
+        type=dict(type="str", default="influxdb", choices=["influxdb", "graphite"]),
+        server=dict(type="str", required=True),
+        protocol=dict(
+            type="str",
+            default="udp",
+            choices=["udp", "tcp", "http", "https"],
+        ),
+        disable=dict(type="bool", default=False),
+        organization=dict(type="str"),
+        bucket=dict(type="str"),
+        token=dict(type="str"),
+        path=dict(type="str"),
+        api_path_prefix=dict(type="str"),
+        timeout=dict(type="int"),
+        max_body_size=dict(type="bytes"),
+        mtu=dict(type="int"),
+        verify_certificate=dict(type="bool"),
+        state=dict(default="present", choices=["present", "absent"], type="str"),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[
+            ["protocol", "http", ["organization", "bucket", "token"]],
+            ["protocol", "https", ["organization", "bucket", "token"]],
+        ],
+        mutually_exclusive=[
+            ("organization", "mtu"),
+            ("bucket", "mtu"),
+            ("token", "mtu"),
+            ("api_path_prefix", "mtu"),
+            ("timeout", "mtu"),
+            ("max_body_size", "mtu"),
+            ("verify_certificate", "mtu"),
+            ("organization", "path"),
+            ("bucket", "path"),
+            ("token", "path"),
+            ("api_path_prefix", "path"),
+            ("max_body_size", "path"),
+            ("verify_certificate", "path"),
+        ],
+    )
+
+    if (
+        module.params["protocol"] in ["tcp", "http", "https"]
+        and module.params["mtu"] is not None
+    ):
+        module.fail_json(
+            msg="The 'mtu' parameter is only available for 'udp' protocol."
+        )
+
+    if module.params["type"] == "graphite" and module.params["protocol"] not in [
+        "tcp",
+        "udp",
+    ]:
+        module.fail_json(
+            msg="The 'protocol' parameter must be 'tcp' or 'udp' for 'graphite' type."
+        )
+
+    if module.params["type"] == "influxdb" and module.params["protocol"] == "tcp":
+        module.fail_json(
+            msg="The 'protocol' parameter must be 'udp', 'http' or 'https' for 'influxdb' type."
+        )
+
+    if module.params["type"] == "influxdb" and module.params["path"] is not None:
+        module.fail_json(
+            msg="The 'path' parameter is only available for 'graphite' type."
+        )
+
+    if (
+        module.params["protocol"] in ["http", "https"]
+        and module.params["type"] == "graphite"
+    ):
+        module.fail_json(
+            msg="The 'protocol' parameter must be 'tcp' or 'udp' for 'graphite' type."
+        )
+
+    if module.params["type"] == "graphite" and (
+        module.params["bucket"] is not None
+        or module.params["organization"] is not None,
+        module.params["token"] is not None,
+    ):
+        module.fail_json(
+            msg="The 'bucket', 'organization' and 'token' parameters are only available for 'influxdb' type."
+        )
+
+    if module.params["protocol"] == "udp" and module.params["timeout"] is not None:
+        module.fail_json(
+            msg="The 'timeout' parameter is only available for 'influxdb' with http v2 api or Graphite TCP socket."
+        )
+
+    if module.params["max_body_size"] is not None and (
+        module.params["protocol"] in ["udp"] or module.params["type"] == "graphite"
+    ):
+        module.fail_json(
+            msg="The 'max_body_size' parameter is only available for 'influxdb' with http v2 api."
+        )
+
+    if (
+        module.params["protocol"] != "https"
+        and module.params["verify_certificate"] is not None
+    ):
+        module.fail_json(
+            msg="The 'verify_certificate' parameter is only available for 'influxdb' with https."
+        )
+
+    server = ProxmoxMetricServer(module)
+
+    changed = False
+    error = None
+    result = {}
+    result["id"] = server.id
+    result["state"] = server.state
+    result["changed"] = False
+
+    if server.state == "absent":
+        if server.exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = server.remove_server()
+    elif server.state == "present":
+        if not server.exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = server.create_server()
+        else:
+            (updated_fields, error) = server.modify_server()
+
+            if updated_fields:
+                changed = True
+                result["updated_fields"] = updated_fields
+
+    # Very gross hack to ignore the error message when Proxmox tries to remove non-existent credentials file
+    # See : https://forum.proxmox.com/threads/interface-comes-up-with-all-question-marks.83287/post-382099
+    # TODO: Check if the error message is still appearing in version < 7.4-17
+    if error is not None and not error.startswith("removing {} credentials file".format(server.type)):
+        module.fail_json(name=server.id, msg=error)
+
+    result["changed"] = changed
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -415,6 +415,27 @@
     - not pve_cluster_enabled | bool or (pve_cluster_enabled and inventory_hostname == groups[pve_group][0])
     - pve_domains_cfg | length > 0
 
+- name: Add metric servers
+  proxmox_metric_server:
+    id: "{{ item.id | default(omit) }}"
+    port: "{{ item.port | default(omit) }}"
+    server: "{{ item.server | default(omit) }}"
+    type: "{{ item.type | default(omit) }}"
+    protocol: "{{ item.protocol | default(omit) }}"
+    disable: "{{ item.disable | default(omit) }}"
+    organization: "{{ item.organization | default(omit) }}"
+    bucket: "{{ item.bucket | default(omit) }}"
+    token: "{{ item.token | default(omit) }}"
+    path: "{{ item.path | default(omit) }}"
+    api_path_prefix: "{{ item.api_path_prefix | default(omit) }}"
+    timeout: "{{ item.timeout | default(omit) }}"
+    max_body_size: "{{ item.max_body_size | default(omit) }}"
+    mtu: "{{ item.mtu | default(omit) }}"
+    verify_certificate: "{{ item.verify_certificate | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+  loop: "{{ pve_metric_servers }}"
+  when: pve_metric_servers is defined and pve_metric_servers | length > 0
+
 - import_tasks: ssl_config.yml
   when:
     - "pve_ssl_private_key is defined"

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -53,3 +53,41 @@
         - name: Create host SSL certificate
           shell: "openssl x509 -req -in {{ ssl_host_csr_path }} -CA {{ ssl_ca_cert_path }} -CAkey {{ ssl_ca_key_path }} -days 1 -CAcreateserial -sha256 -out {{ ssl_host_cert_path }}"
       delegate_to: localhost
+    - name: Install telegraf for metric server testing
+      block:
+        - name: Get the GPG key
+          ansible.builtin.get_url:
+            url: https://repos.influxdata.com/influxdata-archive.key
+            dest: /etc/apt/trusted.gpg.d/influxdata-archive.asc
+            mode: "0644"
+            owner: root
+            group: root
+        - name: Add the repository
+          ansible.builtin.apt_repository:
+            repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.asc] https://repos.influxdata.com/debian stable main"
+            state: present
+            update_cache: true
+            filename: "influxdata"
+        - name: Install Telegraf
+          ansible.builtin.apt:
+            name: telegraf
+            state: present
+        - name: Configure Telegraf
+          ansible.builtin.copy:
+            dest: /etc/telegraf/telegraf.conf
+            mode: "0644"
+            content: |
+              [agent]
+                interval = "10s"
+                collection_jitter = "0s"
+                flush_interval = "10s"
+                flush_jitter = "0s"
+                precision = ""
+                hostname = "{{ ansible_hostname }}"
+                omit_hostname = false
+              [[inputs.socket_listener]]
+                service_address = "udp://127.0.0.1:8089"
+        - name: Restart Telegraf
+          ansible.builtin.systemd:
+            name: telegraf
+            state: restarted


### PR DESCRIPTION
Tested only with PVE 7

Telegraf can be used to transfert metrics to Prometheus, Elasticsearch, etc.

Resolve #259 
