### PR TITLE
Run Vagrant in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt install python3-jmespath python3-netaddr
+      - run: sudo apt install python3-jmespath python3-netaddr nfs-kernel-server
       - run: ansible-galaxy install geerlingguy.ntp
       - name: setup vagrant
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+---
+name: CI
+
+"on":
+  pull_request: {}
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  vagrant-deploy:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install jmespath netaddr
+      - run: ansible-galaxy install geerlingguy.ntp
+      - name: setup vagrant
+        run: |
+          # Copyright The containerd Authors
+          # 
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          # 
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          # 
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
+          sudo systemctl enable --now libvirtd
+          sudo apt-get build-dep -y vagrant ruby-libvirt
+          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
+          sudo vagrant plugin install vagrant-libvirt
+      - run: sudo vagrant up --no-tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,6 @@ jobs:
           ANSIBLE_STDOUT_CALLBACK=debug
           ANSIBLE_DISPLAY_SKIPPED_HOSTS=no
           ANSIBLE_DISPLAY_OK_HOSTS=no
+          DEBIAN_FRONTEND=noninteractive
           PATH=$PIPX_BIN_DIR:$PATH
-          vagrant up --no-tty
+          vagrant up --no-tty || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,10 @@ jobs:
           sudo apt-get build-dep -y vagrant ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
           vagrant plugin install vagrant-libvirt
-      - run: sudo -E -u ${USER} PATH=$PIPX_BIN_DIR:$PATH vagrant up --no-tty
+      - run: >
+          sudo -E -u ${USER}
+          ANSIBLE_STDOUT_CALLBACK=debug
+          ANSIBLE_DISPLAY_SKIPPED_HOSTS=no
+          ANSIBLE_DISPLAY_OK_HOSTS=no
+          PATH=$PIPX_BIN_DIR:$PATH
+          vagrant up --no-tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
           sudo systemctl enable --now libvirtd
+          sudo usermod -aG libvirt ${USER}
           sudo apt-get build-dep -y vagrant ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
-          sudo vagrant plugin install vagrant-libvirt
-      - run: sudo PATH=$PIPX_BIN_DIR:$PATH vagrant up --no-tty
+          vagrant plugin install vagrant-libvirt
+      - run: sudo -E -u ${USER} PATH=$PIPX_BIN_DIR:$PATH vagrant up --no-tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   vagrant-deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt install python3-jmespath python3-netaddr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt install python3-jmespath python3-netaddr nfs-kernel-server
+      - run: sudo apt install nfs-kernel-server
+      - run: sudo pipx inject ansible-core jmespath netaddr
       - run: ansible-galaxy install geerlingguy.ntp
       - name: setup vagrant
         run: |
@@ -48,4 +49,4 @@ jobs:
           sudo apt-get build-dep -y vagrant ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
           sudo vagrant plugin install vagrant-libvirt
-      - run: sudo vagrant up --no-tty
+      - run: sudo PATH=$PIPX_BIN_DIR:$PATH vagrant up --no-tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: pip install jmespath netaddr
+      - run: sudo apt install python3-jmespath python3-netaddr
       - run: ansible-galaxy install geerlingguy.ntp
       - name: setup vagrant
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+---
+yaml:
+  rules:
+    line-length:
+      max: 120


### PR DESCRIPTION
This just runs vagrant with the development `Vagrantfile`, mostly just to provide a sanity check/guideline for PRs, and a start to resolve #166. It should be replaced later to re-use existing test playbooks.
