### PR TITLE
Add the abillity to set extra pubkeys in root`s authorized_keys via this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ This is useful if you want to use InfluxDB, Graphite or other (with telegraf).
 a port other than the default 22, please set this variable. If a new node is
 joining the cluster, the PVE cluster needs to communicate once via SSH.
 
+`pve_ssh_extra_keys` allows you to add additional SSH public keys to the root
+users SSH authorized_keys, which are declaratively managed, so that keys that
+are not specified anymore, will get removed... requires `pve_groups` to be set
+right and `pve_manage_ssh` to be true.
+
 `pve_manage_ssh` (default true) allows you to disable any changes this module
 would make to your SSH server config. This is useful if you use another role
 to manage your SSH server. Note that setting this to false is not officially

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ pve_acls: []
 pve_storages: []
 pve_metric_servers: []
 pve_ssh_port: 22
+pve_ssh_extra_keys: []
 pve_manage_ssh: true
 pve_hooks: {}
 pve_no_log: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,9 @@ pve_cluster_addr0: "{{ ansible_default_ipv4.address if ansible_default_ipv4.addr
 # pve_cluster_addr1: "{{ ansible_eth1.ipv4.address }}
 # pve_cluster_addr0_priority: 0
 # pve_cluster_addr1_priority: 1
+pve_acme_enabled: no
+# pve_acme_directory: "ACME directory to register on/get certificates from"
+# pve_acme_contact: "email address for Let's Encrypt"
 pve_datacenter_cfg: {}
 pve_domains_cfg: []
 pve_cluster_ha_groups: []

--- a/library/proxmox_acme_account.py
+++ b/library/proxmox_acme_account.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['stableinterface'],
+    'supported_by': 'lae'
+}
+
+DOCUMENTATION = '''
+---
+module: proxmox_acme_account
+
+short_description: Manages ACME configs/account registrations in Proxmox
+
+options:
+    name:
+        default: "default"
+        description:
+            - Name of the ACME config to manage.
+    state:
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+        description:
+            - Specifies whether the ACME account config should exist or not.
+    directory:
+        required: false
+        default: https://acme-v02.api.letsencrypt.org/directory
+        description:
+            - Specifies which ACME directory to register against.
+    contact:
+        required: true
+        description:
+            - Sets the contact email for the ACME account.
+
+author:
+    - Musee Ullah (@lae)
+'''
+
+EXAMPLES = '''
+- name: Create default ACME configuration
+  proxmox_acme_account:
+    contact: hello@example.com
+- name: Create secondary ACME configuration on staging
+  proxmox_acme_account:
+    name: secondary
+    directory: https://acme-staging-v02.api.letsencrypt.org/directory
+    contact: test@example.com
+'''
+
+RETURN = '''
+updated_fields:
+    description: Fields that were modified for an existing account config
+    type: list
+account:
+    description: Information about the account fetched from PVE after this task completed. (output for this is currently disabled since it contains a private key)
+    type: json
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.pvesh import ProxmoxShellError
+import ansible.module_utils.pvesh as pvesh
+
+class ProxmoxACMEAccount(object):
+    def __init__(self, module):
+        self.module = module
+        self.name = module.params['name']
+        self.state = module.params['state']
+        self.directory = module.params['directory']
+        self.contact = module.params['contact']
+
+    def lookup(self):
+        try:
+            return pvesh.get("cluster/acme/account/{}".format(self.name))
+        except ProxmoxShellError as e:
+            self.module.fail_json(msg=e.message, status_code=e.status_code, **result)
+
+    def identify_tos(self):
+        try:
+            return pvesh.get("cluster/acme/tos")
+        except ProxmoxShellError as e:
+            self.module.fail_json(msg=e.message, status_code=e.status_code, **result)
+
+    def remove_account(self):
+        try:
+            pvesh.delete("cluster/acme/account/{}".format(self.name))
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def create_account(self):
+        new_account = {
+            'name': self.name,
+            'directory': self.directory,
+            'contact': self.contact,
+            'tos_url': self.identify_tos()
+        }
+
+        try:
+            pvesh.create("cluster/acme/account/", **new_account)
+            return (True, None)
+        except ProxmoxShellError as e:
+            return (False, e.message)
+
+    def modify_account(self):
+        lookup = self.lookup()
+
+        updated_fields = []
+        recreate_account = False
+        error = None
+
+        if lookup['account']['contact'][0].split(':')[1] != self.contact:
+            updated_fields.append('contact')
+
+        if lookup['directory'] != self.directory:
+            updated_fields.append('directory')
+            recreate_account = True
+
+        if lookup['tos'] != self.identify_tos():
+            updated_fields.append('tos')
+            recreate_account = True
+
+        if self.module.check_mode:
+            self.module.exit_json(changed=bool(updated_fields), expected_changes=updated_fields, would_recreate=recreate_account)
+
+        if not updated_fields:
+            # No changes necessary
+            return (updated_fields, recreate_account, error)
+
+        try:
+            if recreate_account:
+                self.remove_account()
+                self.create_account()
+            else:
+                pvesh.set("cluster/acme/account/{}".format(self.name), contact=self.contact)
+        except ProxmoxShellError as e:
+            error = e.message
+
+        return (updated_fields, recreate_account, error)
+
+def main():
+    # Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html
+    module = AnsibleModule(
+        argument_spec = dict(
+            name=dict(default='default', type='str'),
+            state=dict(choices=['present', 'absent'], default='present', type='str'),
+            directory=dict(default='https://acme-v02.api.letsencrypt.org/directory', type='str'),
+            contact=dict(default=None, required=True, type='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    account = ProxmoxACMEAccount(module)
+
+    changed = False
+    error = None
+    result = {}
+    result['name'] = account.name
+    result['state'] = account.state
+
+    if account.state == 'absent':
+        if account.lookup() is not None:
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = account.remove_account()
+
+            if error is not None:
+                module.fail_json(name=account.name, msg=error)
+    elif account.state == 'present':
+        if not account.lookup():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (changed, error) = account.create_account()
+        else:
+            # modify account (note: this function is check mode aware)
+            (updated_fields, recreate_account, error) = account.modify_account()
+
+            if updated_fields:
+                changed = True
+                result['updated_fields'] = updated_fields
+                result['account_recreated'] = recreate_account
+
+        if error is not None:
+            module.fail_json(name=account.name, msg=error)
+
+    """
+    # The following contains sensitive data, so for now don't include it in the
+    # module output. I think there's a flag to check for that lets you decide
+    # how to handle outputting of sensitive output that we should use here.
+    lookup = account.lookup()
+    if lookup is not None:
+        result['account'] = lookup
+    """
+
+    result['changed'] = changed
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/tasks/acme_config.yml
+++ b/tasks/acme_config.yml
@@ -1,0 +1,5 @@
+---
+- name: Create the default ACME account
+  proxmox_acme_account:
+    contact: "{{ pve_acme_contact }}"
+    directory: "{{ pve_acme_directory | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,18 @@
           did you specify the pve_group host variable correctly?"
   when: "pve_cluster_enabled | bool or pve_manage_ssh | bool"
 
+- name: Ensure ACME is not enabled when an SSL key/certificate is provided
+  fail:
+    msg: "You cannot use ACME/Let's Encrypt while using your own private key/certificate."
+  when:
+    - pve_ssl_private_key is defined and pve_acme_enabled
+
+- name: Ensure contact email is specified when using Let's Encrypt
+  fail:
+    msg: "Please set pve_acme_contact to a valid email."
+  when:
+    - pve_acme_enabled and pve_acme_contact is not defined
+
 - import_tasks: ssh_config.yml
   when:
     - "pve_manage_ssh | bool"
@@ -418,3 +430,6 @@
   when:
     - "pve_ssl_private_key is defined"
     - "pve_ssl_certificate is defined"
+
+- import_tasks: acme_config.yml
+  when: pve_acme_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
       - "inventory_hostname in groups[pve_group]"
     msg: "This host does not appear to be in the group {{ pve_group }}, \
           did you specify the pve_group host variable correctly?"
-  when: "pve_cluster_enabled | bool"
+  when: "pve_cluster_enabled | bool or pve_manage_ssh | bool"
 
 - import_tasks: ssh_config.yml
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,10 @@
           did you specify the pve_group host variable correctly?"
   when: "pve_cluster_enabled | bool"
 
+- import_tasks: ssh_config.yml
+  when:
+    - "pve_manage_ssh | bool"
+
 - import_tasks: ssh_cluster_config.yml
   when:
     - "pve_manage_ssh | bool and pve_cluster_enabled | bool"

--- a/tasks/ssh_cluster_config.yml
+++ b/tasks/ssh_cluster_config.yml
@@ -1,29 +1,4 @@
 ---
-- name: Create SSH directory for root
-  file:
-    path: /root/.ssh/
-    state: directory
-    mode: 0700
-
-- name: Create root SSH key pair for PVE
-  user:
-    name: root
-    generate_ssh_key: yes
-    ssh_key_file: /root/.ssh/id_rsa
-    ssh_key_type: rsa
-    ssh_key_comment: "root@{{ inventory_hostname_short }}"
-
-- name: Fetch root SSH public key
-  slurp:
-    src: /root/.ssh/id_rsa.pub
-  register: proxmox_root_id_rsa_pub
-
-- name: Authorize all hosts' root SSH public keys
-  authorized_key:
-    user: root
-    key: "{{ hostvars[item].proxmox_root_id_rsa_pub.content | b64decode }}"
-  with_items: "{{ groups[pve_group] }}"
-
 - name: Configure SSH clients for connecting to PVE cluster hosts
   blockinfile:
     dest: /etc/ssh/ssh_config

--- a/tasks/ssh_config.yml
+++ b/tasks/ssh_config.yml
@@ -1,0 +1,30 @@
+---
+- name: Create SSH directory for root
+  file:
+    path: /root/.ssh/
+    state: directory
+    mode: 0700
+
+- name: Create root SSH key pair for PVE
+  user:
+    name: root
+    generate_ssh_key: yes
+    ssh_key_file: /root/.ssh/id_rsa
+    ssh_key_type: rsa
+    ssh_key_comment: "root@{{ inventory_hostname_short }}"
+
+- name: Fetch root SSH public key
+  slurp:
+    src: /root/.ssh/id_rsa.pub
+  register: proxmox_root_id_rsa_pub
+
+- name: Accumulate all hosts' root SSH public keys
+  set_fact:
+    _pve_root_ssh_pubkeys: "{{ _pve_root_ssh_pubkeys | default([]) | union([hostvars[item].proxmox_root_id_rsa_pub.content | b64decode]) }}"
+  with_items: "{{ groups[pve_group] }}"
+
+- name: Authorize SSH public keys for root user
+  authorized_key:
+    user: root
+    key: "{{ pve_ssh_extra_keys | default([]) | union(_pve_root_ssh_pubkeys) | join('\n') }}"
+    exclusive: "{{ pve_ssh_extra_keys | default([]) | length > 0 }}"


### PR DESCRIPTION
Hello,

with these changes (which I may have to change again if it is not perfect, but it works as expected with 3 node cluster as well as non-cluster node with own infra tested) I have implemented the possibility to manage the authorized_keys via optional variable via this role.

As long as the var `pve_ssh_extra_keys` is not set, not much will change.

Where I have changed something else is that I have moved the whole authorized_keys part to a new tasks file. The reason is that I don't quite understand why this is limited to clusters and single node constructs can't work with the variable `pve_ssh_extra_keys` and any other ssh management stuff in the future. If you don't want that (ssh management) you can still set `pve_manage_ssh` to false.

Now to what I have tested. So I just used the `exclusive` specification, which is only set to true if `pve_ssh_extra_keys` is set and longer than 0 (i.e. contains something) to make sure that it does not accidentally interfere with existing setups (assuming you manage authorized_keys with another role). In the defaults, the variable is set empty (= length 0).

Here is a visual comparison:

![extra_keys_disabled](https://github.com/user-attachments/assets/0b22099e-7f91-4364-a66a-e8f6d39adc69)
![extra_keys_enabled](https://github.com/user-attachments/assets/556d2278-5611-4547-94e5-1be13c50defd)

Criticism/improvements very welcome! I really want this feature and use it myself now. Because the implementation of an additional role is a bit more difficult in this case (if you want to make sure that there are really only exactly the proxmox own keys + defined ones and manual added keys get overwritten).