### PR TITLE
Don't run Amplify on PRs from forks

### DIFF
--- a/.github/workflows/amplify.yml
+++ b/.github/workflows/amplify.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   workflow_dispatch: {}
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 permissions:
   contents: read
@@ -14,9 +14,9 @@ jobs:
   amplify-security-scan:
     name: Amplify Security Scan
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
+    if: (!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Amplify Runner
         uses: amplify-security/runner-action@926f003f3c9695a93cbc4e2f1e64eb784dcacbfc  # v0.2.0


### PR DESCRIPTION
GitHub does not mint OIDC tokens for externally sourced PRs so this workflow can't successfully run on those PRs. An alternative solution (like via an approval comment?) should be identified and implemented eventually to allow the workflow for previous contributors using their own forks.

This also updates the workflow to run on the develop branch.
