### PR TITLE
[Breaking Change] No subscription bugfixes for automated installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ serially during a maintenance period.) It will also enable the IPMI watchdog.
 ```
 [variable]: [default] #[description/purpose]
 pve_group: proxmox # host group that contains the Proxmox hosts to be clustered together
-pve_repository_line: "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" # apt-repository configuration - change to enterprise if needed (although TODO further configuration may be needed)
+pve_enterprise_repository: false # false = pve-no-subscription (tested) and true = enterprise (not tested, but should work in theory. Please report a bug if not)
 pve_remove_subscription_warning: true # patches the subscription warning messages in proxmox if you are using the community edition
 pve_extra_packages: [] # Any extra packages you may want to install, e.g. ngrep
 pve_run_system_upgrades: false # Let role perform system upgrades
@@ -411,7 +411,8 @@ pve_zfs_enabled: no # Specifies whether or not to install and configure ZFS pack
 # pve_zfs_zed_email: "" # Should be set to an email to receive ZFS notifications
 pve_zfs_create_volumes: [] # List of ZFS Volumes to create (to use as PVE Storages). See section on Storage Management.
 pve_ceph_enabled: false # Specifies wheter or not to install and configure Ceph packages. See below for an example configuration.
-pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-pacific bookworm main" # apt-repository configuration. Will be automatically set for 6.x and 7.x (Further information: https://pve.proxmox.com/wiki/Package_Repositories)
+pve_ceph_enterprise_repository: false # false = no-subscription (tested) and true = enterprise (not tested, but should work in theory. Please report a bug if not)
+# pve_ceph_release: "" # if not set, the default ceph version that is configured with your PVE version is not changed. This variable can be used to override the ceph release, for example "quincy" or "squid"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}" # Ceph public network
 # pve_ceph_cluster_network: "" # Optional, if the ceph cluster network is different from the public network (see https://pve.proxmox.com/pve-docs/chapter-pveceph.html#pve_ceph_install_wizard)
 pve_ceph_nodes: "{{ pve_group }}" # Host group containing all Ceph nodes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible-role-proxmox
 pve_group: proxmox
-pve_repository_line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
+pve_enterprise_repository: false
 pve_remove_subscription_warning: true
 pve_extra_packages: []
 pve_check_for_kernel_update: true
@@ -28,7 +28,8 @@ pve_zfs_enabled: no
 # pve_zfs_zed_email: "email address for zfs events"
 pve_zfs_create_volumes: []
 pve_ceph_enabled: false
-pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'buster' %}ceph-nautilus buster{% else %}ceph-quincy bullseye{% endif %} main"
+pve_ceph_enterprise_repository: false
+# pve_ceph_release: "" # if not set, the default ceph version that is configured with your PVE version is not changed. This variable can be used to override the ceph release, for example "quincy" or "squid"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"
 pve_ceph_nodes: "{{ pve_group }}"
 pve_ceph_mon_group: "{{ pve_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,20 +132,70 @@
     name: os-prober
     state: absent
 
-- name: Add Proxmox repository
-  apt_repository:
-    repo: "{{ pve_repository_line }}"
-    filename: proxmox
-    state: present
-  register: _pve_repo
+- name: Update Proxmox repository to no-subscription if pve_enterprise_repository is false
+  block:
+    - name: Add no-subscription repository to /etc/apt/sources.list
+      lineinfile:
+        path: /etc/apt/sources.list
+        line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
+        state: present
+      register: _pve_repo
+    - name: Remove enterprise repository from /etc/apt/sources.list
+      lineinfile:
+        path: /etc/apt/sources.list.d/pve-enterprise.list
+        line: "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
+        state: absent
+      register: _pve_repo
+  when: not pve_enterprise_repository
 
-- name: Add Proxmox Ceph repository
-  apt_repository:
-    repo: '{{ pve_ceph_repository_line }}'
-    filename: ceph
-    state: present
+- name: Update Proxmox repository to enterprise if pve_enterprise_repository is true
+  block:
+    - name: Remove no-subscription repository from /etc/apt/sources.list
+      lineinfile:
+        path: /etc/apt/sources.list
+        line: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
+        state: absent
+      register: _pve_repo
+    - name: Add enterprise repository to /etc/apt/sources.list
+      lineinfile:
+        path: /etc/apt/sources.list.d/pve-enterprise.list
+        line: "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
+        state: present
+      register: _pve_repo
+  when: pve_enterprise_repository
+
+- name: Update Ceph repository to no-subscription if pve_ceph_enterprise_repository is false
+  lineinfile:
+    path: /etc/apt/sources.list.d/ceph.list
+    regexp: '^deb https://enterprise.proxmox.com/debian/ceph-(.*) (.*) enterprise'
+    line: 'deb http://download.proxmox.com/debian/ceph-\1 \2 no-subscription'
+    backrefs: yes
   register: _pve_ceph_repo
-  when: "pve_ceph_enabled | bool"
+  when:
+    - pve_ceph_enabled 
+    - not pve_ceph_enterprise_repository
+
+- name: Update Ceph repository to enterprise if pve_ceph_enterprise_repository is true
+  lineinfile:
+    path: /etc/apt/sources.list.d/ceph.list
+    regexp: '^deb http://download.proxmox.com/debian/ceph-(.*) (.*) no-subscription'
+    line: 'deb https://enterprise.proxmox.com/debian/ceph-\1 \2 enterprise'
+    backrefs: yes
+  register: _pve_ceph_repo
+  when:
+    - pve_ceph_enabled
+    - pve_ceph_enterprise_repository
+
+- name: Update Ceph release version
+  ansible.builtin.replace:
+    path: /etc/apt/sources.list.d/ceph.list
+    regexp: 'ceph-(\w+)'
+    replace: "ceph-{{ pve_ceph_release }}"
+  register: _pve_ceph_repo
+  when:
+    - pve_ceph_enabled
+    - pve_ceph_release is defined
+    - pve_ceph_release | length > 0
 
 - name: Run apt-get dist-upgrade on repository changes
   apt:
@@ -194,27 +244,16 @@
   register: _proxmox_install
   until: _proxmox_install is succeeded
 
-- block:
-    - name: Remove automatically installed PVE Enterprise repo configuration
-      apt_repository:
-        repo: "{{ item }}"
-        filename: pve-enterprise
-        state: absent
-      with_items:
-        - "deb https://enterprise.proxmox.com/debian {{ ansible_distribution_release }} pve-enterprise"
-        - "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
-
-    - name: Remove subscription check wrapper function in web UI
-      ansible.builtin.lineinfile:
-        path: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
-        line: '        orig_cmd(); return;'
-        insertafter: '^\s+checked_command: function\(orig_cmd\) {$'
-        firstmatch: yes
-        backup: yes
-      when:
-        - "pve_remove_subscription_warning | bool"
+- name: Remove subscription check wrapper function in web UI
+  ansible.builtin.lineinfile:
+    path: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+    line: '        orig_cmd(); return;'
+    insertafter: '^\s+checked_command: function\(orig_cmd\) {$'
+    firstmatch: yes
+    backup: yes
   when:
-    - "'pve-no-subscription' in pve_repository_line"
+    - "pve_remove_subscription_warning | bool"
+    - not pve_enterprise_repository
 
 - import_tasks: pcie_passthrough.yml
   when: "pve_pcie_passthrough_enabled | bool"


### PR DESCRIPTION
I am currently trying to fully automate Proxmox Cluster + Ceph provisioning via your awesome Ansible role after utilizing a custom generatated Proxmox VE ISO described in the [Proxmox wiki](https://pve.proxmox.com/wiki/Automated_Installation).

With v1.9.1 of this role I get some errors seen in the screenshot below. This PR draft aims to fix this and allows a fully automated installation with no enterprise subscription for neither Proxmox VE nor Ceph and also allows optional Ceph release override.

I am opening this as a draft since I am not sure if I am going in the right direction and would like to kindly ask for some feedback. This might be the beginning of a series of pull requests if it is okay for you and if you are interested.

Also please do not merge it yet, since it is a breaking change regarding the configuration variables of this role and I had no proper time to test it yet.

![image](https://github.com/user-attachments/assets/9f090f59-de6a-463d-b27e-dd98445057a8)
