### PR TITLE
fix: disable apt cache update during repo addition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -141,6 +141,7 @@
     repo: "{{ pve_repository_line }}"
     filename: proxmox
     state: present
+    update_cache: no
   register: _pve_repo
 
 - name: Add Proxmox Ceph repository


### PR DESCRIPTION
This PR adds `update_cache: no` to the `Add Proxmox repository` task in order to resolve the issue below.

For some reason, on my newly provisioned Proxmox 8 nodes, apt was attempting to update its index every time the task ran, resulting in the following errors:

```json
{
"changed": false,
"msg": "Failed to update apt cache: E:Failed to fetch "
"https://enterprise.proxmox.com/debian/ceph-quincy/dists/bookworm/InRelease"
"401  Unauthorized [IP: 170.130.165.90 443], E:The repository"
"'https://enterprise.proxmox.com/debian/ceph-quincy bookworm InRelease' is not signed.,"
"W:Updating from such a repository can't be done securely, and is therefore disabled by default.,"
"W:See apt-secure(8) manpage for repository creation and user configuration details.,"
"E:Failed to fetch https://enterprise.proxmox.com/debian/pve/dists/bookworm/InRelease "
"401  Unauthorized [IP: 170.130.165.90 443],"
"E:The repository 'https://enterprise.proxmox.com/debian/pve bookworm InRelease' is not signed.",
}](item: deb https://enterprise.proxmox.com/debian/pve bookworm pve-enterprise)
```
According to the [Ansible docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html), it seems that the `apt_repository` module defaults to `update_cache: true`, which won't work if the offending entry is still there.

I noticed that a similar change has already been applied to the `Remove automatically installed PVE Enterprise repo configuration` task in the `develop` branch.

I tested this PR against a fresh install of Proxmox VE 8.3.
I was not able to to test using the Vagrant file due to architecture limitations of the supported providers (I am on Arm64).