### PR TITLE
Add support for --crush-device-class in ceph OSD creation

### DIFF
--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -55,6 +55,7 @@
     - name: Create Ceph OSDs
       ansible.builtin.command: >-
         pveceph osd create {{ item.device }}
+        {% if "crush.device.class" in item %}--crush-device-class {{ item["crush.device.class"] }}{% endif %}
         {% if "encrypted" in item and item["encrypted"] | bool %}--encrypted 1{% endif %}
         {% if "block.db" in item %}--db_dev {{ item["block.db"] }}{% endif %}
         {% if "block.wal" in item %}--wal_dev {{ item["block.wal"] }}{% endif %}


### PR DESCRIPTION
Add the possibility to configure  `--crush-device-class` when creating ceph OSDs.

```
pveceph osd create <dev> [OPTIONS]

Create OSD

<dev>: <string>

    Block device name.
--crush-device-class <string>

    Set the device class of the OSD in crush.
````
https://pve.proxmox.com/pve-docs/pveceph.1.html