### PR TITLE
Add create_subdirs parameter for storage + fix is_mountpoint parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,12 +683,11 @@ pve_storages:
     username: user
     password: supersecurepass
     domain: addomain.tld
-  - name: remote-cifs-truenas01
+  - name: empty-dir
     type: dir
-    path: /mnt/nas
+    path: /mnt/empty-dir
     content: [ "images", "rootdir" ]
     create_subdirs: false
-    is_mountpoint: true
 ```
 
 Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html for more information.

--- a/README.md
+++ b/README.md
@@ -683,6 +683,12 @@ pve_storages:
     username: user
     password: supersecurepass
     domain: addomain.tld
+  - name: remote-cifs-truenas01
+    type: dir
+    path: /mnt/nas
+    content: [ "images", "rootdir" ]
+    create_subdirs: false
+    is_mountpoint: true
 ```
 
 Refer to https://pve.proxmox.com/pve-docs/api-viewer/index.html for more information.

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -161,6 +161,11 @@ options:
         description:
             - Specifies whether or not the given path is an externally managed
             mountpoint.
+    create_subdirs        
+         required: false
+        type: bool
+        description:
+            - Specifies whether or not to populate the directory with the default structure.
     namespace:
         required: false
         type: str
@@ -314,6 +319,7 @@ class ProxmoxStorage(object):
         self.thinpool = module.params['thinpool']
         self.sparse = module.params['sparse']
         self.is_mountpoint = module.params['is_mountpoint']
+        self.create_subdirs = module.params['create_subdirs']
 
         # namespace for pbs
         self.namespace = module.params['namespace']
@@ -414,6 +420,8 @@ class ProxmoxStorage(object):
             args['sparse'] = 1 if self.sparse else 0
         if self.is_mountpoint is not None:
             args['is_mountpoint'] = 1 if self.is_mountpoint else 0
+        if self.create_subdirs is not None:
+            args['create-subdirs'] = 1 if self.create_subdirs else 0
 
         # CIFS
         if self.subdir is not None:
@@ -587,6 +595,7 @@ def main():
         thinpool=dict(default=None, type='str', required=False),
         sparse=dict(default=None, type='bool', required=False),
         is_mountpoint=dict(default=None, type='bool', required=False),
+        create_subdirs=dict(default=None, type='bool', required=False),
         namespace=dict(default=None, type='str', required=False),
         subdir=dict(default=None, type='str', required=False),
         domain=dict(default=None, type='str', required=False),

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -349,6 +349,8 @@
     domain: "{{ item.domain | default(omit) }}"
     subdir: "{{ item.subdir | default(omit) }}"
     share: "{{ item.share | default(omit) }}"
+    create_subdirs: "{{ item.create_subdirs | default(omit) }}"
+    is_mountpoint: "{{ item.is_mountpoint | default(omit) }}"
   no_log: "{{ pve_no_log }}"
   with_items: "{{ pve_storages }}"
   when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"


### PR DESCRIPTION
- Added the parameter is_mountpoint to the proxmox_storage module invocation
- Added the create_subdirs parameter to the proxmox_storage module to optionally disable default folders creation on the storage by proxmox.
- Updated Readme