### PR TITLE
added the shared box ticking variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -349,6 +349,7 @@
     domain: "{{ item.domain | default(omit) }}"
     subdir: "{{ item.subdir | default(omit) }}"
     share: "{{ item.share | default(omit) }}"
+    shared: "{{ item.shared | default(omit) }}"
     create_subdirs: "{{ item.create_subdirs | default(omit) }}"
     is_mountpoint: "{{ item.is_mountpoint | default(omit) }}"
   no_log: "{{ pve_no_log }}"


### PR DESCRIPTION
I saw that in the proxmox_storage.py there is functionality to also tick or untick the "Shared" box for storage. This is not however used in main.yml in the "Configure Proxmox Storage" task. I added it there now and can confirm it ticks and unticks that box just fine.

![image](https://github.com/user-attachments/assets/c7c83c37-2168-48ae-b955-dcc407b839d0)
