### PR TITLE
set ceph versions and component for proxmox repositories depending on debian releases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ pve_zfs_enabled: no
 # pve_zfs_zed_email: "email address for zfs events"
 pve_zfs_create_volumes: []
 pve_ceph_enabled: false
-pve_ceph_repository_line: "deb http://download.proxmox.com/debian/{% if ansible_distribution_release == 'buster' %}ceph-nautilus buster{% else %}ceph-quincy bullseye{% endif %} main"
+pve_ceph_repository_line: "deb http://download.proxmox.com/debian/ceph-{{ pve_ceph_default_version }} {{ ansible_distribution_release }} {{ pve_ceph_debian_component }}"
 pve_ceph_network: "{{ (ansible_default_ipv4.network +'/'+ ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"
 pve_ceph_nodes: "{{ pve_group }}"
 pve_ceph_mon_group: "{{ pve_group }}"

--- a/vars/debian-bookworm.yml
+++ b/vars/debian-bookworm.yml
@@ -1,2 +1,4 @@
 ---
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_ceph_default_version: reef
+pve_ceph_debian_component: no-subscription

--- a/vars/debian-bullseye.yml
+++ b/vars/debian-bullseye.yml
@@ -2,3 +2,5 @@
 pve_release_key: proxmox-ve-release-7.x.asc
 pve_release_key_id: DD4BA3917E23BF59
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_ceph_default_version: quincy
+pve_ceph_debian_component: main

--- a/vars/debian-buster.yml
+++ b/vars/debian-buster.yml
@@ -2,3 +2,5 @@
 pve_release_key: proxmox-ve-release-6.x.asc
 pve_release_key_id: 7BF2812E8A6E88E0
 pve_ssh_ciphers: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com"
+pve_ceph_default_version: nautilus
+pve_ceph_debian_component: main


### PR DESCRIPTION
Ceph Proxmox repositories offer version switches, and in time changed their component part from main to no-subscription.  Instead of a if/else in the defaults, I propose we set the vars in the debian release vars file!
