### PR TITLE
​

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ With clustering enabled, this role does (or allows you to do) the following:
 
 WARNING: Support for servers provisioned using the Proxmox ISO installer is limited. Use Debian as your base.
 
-## Support/Contributing
-
-For support or if you'd like to contribute to this role but want guidance, feel
-free to join this Discord server: https://discord.gg/cjqr6Fg. Please note, this
-is an temporary invite, so you'll need to wait for @lae to assign you a role,
-otherwise Discord will remove you from the server when you logout.
-
 ## Quickstart
 
 The primary goal for this role is to configure and manage a


### PR DESCRIPTION
Change variable type of "encryption_key" from string to jsonarg as the underlying api throws an error when using an existing encryption key directly inside the variable as it becomes a string which the api doesnt like.

I have the encryption key as a dict in my ansible vault.

Debug output before the fix:
`DEBUG ENCRYPTION_KEY value: "{'kdf': None, 'created': '2022-09-07T08:46:13+02:00', 'modified': '2022-09-07T08:46:13+02:00', 'data': 'xxx', 'fingerprint': 'xxx'}"`

This is my debug output after the fix:
`DEBUG ENCRYPTION_KEY value: {"kdf": null, "created": "2022-09-07T08:46:13+02:00", "modified": "2022-09-07T08:46:13+02:00", "data": "xxx", "fingerprint": "xxx"}`

And this was the error I got when running my playbook:
> ansible_loop_var: item
>   item:
>   content: backup
>   datastore: bpool
>   encryption_key: '{"kdf": null, "created": "2022-09-07T08:46:13+02:00", "modified": "2022-09-07T08:46:13+02:00", "data": "xxx", "fingerprint": "xxx"}'
>   name: pbs2
>   namespace: sbg-1
>   password: xxx
>   server: pbs2.xxx.de
>   type: pbs
>   username: pve-dev@pbs
>   msg: encryption_key needs to be valid JSON or set to 'autogen'.

With this fix my storage configuration is using the encryption key from my ansible vault and can access our backups.