### PR TITLE
Fix Subscription Removal Step Breaking Proxmox UI

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -205,7 +205,7 @@
       ansible.builtin.lineinfile:
         path: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
         line: '        orig_cmd(); return;'
-        insertafter: '^\s+checked_command: function\(orig_cmd\) {$'
+        insertafter: '^\s+checked_command: function \(orig_cmd\) {$'
         firstmatch: yes
         backup: yes
       when:


### PR DESCRIPTION
With the latest update of the `proxmox-widget-toolkit`, the line the `Remove subscription check wrapper function in web UI` task uses to disable the subscription nag has changed:

**Before**
`checked_command: function(orig_cmd) {`

**Now** (There is a space between `function` and `(`)
`checked_command: function (orig_cmd) {`

Since there are no match, the lineinfile now puts the line `'        orig_cmd(); return;'` at the end of the `proxmoxlib.js` which breaks the UI and prevents it from loading.

This PR fixes the `lineinfile insertafter` pattern to fix this issue.