### PR TITLE
Support for new parameter `snapshot-as-volume-chain` in LVM storage configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -352,6 +352,7 @@
     shared: "{{ item.shared | default(omit) }}"
     create_subdirs: "{{ item.create_subdirs | default(omit) }}"
     is_mountpoint: "{{ item.is_mountpoint | default(omit) }}"
+    snapshot_as_volume_chain: "{{ item.snapshot_as_volume_chain | default(omit) }}"
   no_log: "{{ pve_no_log }}"
   with_items: "{{ pve_storages }}"
   when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"


### PR DESCRIPTION
This PR adds a new storage configuration parameter `snapshot-as-volume-chain` for LVM, introduced in Proxmox 9. 

From the [official documentation](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#pvesm_lvm_config):

> snapshot-as-volume-chain
>   Set this flag to enable snapshot support for virtual machines on LVM with a volume backing chain. With this setting, taking a snapshot persists the current state under the snapshot’s name and starts a new volume backed by the snapshot. 
