### PR TITLE
Increase GitHub Runner Space for Vagrant Disks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
     if: ${{ needs.changes.outputs.role == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     steps:
+      - uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 10240
+          build-mount-path: /var/lib/libvirt/images
+          build-mount-path-ownership: 'root:root'
       - uses: actions/checkout@v4
       - run: sudo apt install nfs-kernel-server
       - run: sudo pipx inject ansible-core jmespath netaddr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           root-reserve-mb: 10240
           build-mount-path: /var/lib/libvirt/images
-          build-mount-path-ownership: 'root:root'
       - uses: actions/checkout@v4
       - run: sudo apt install nfs-kernel-server
       - run: sudo pipx inject ansible-core jmespath netaddr


### PR DESCRIPTION
There a some [quick and dirty ways to get more available spaces on a runner](https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930), but I [found an action](https://github.com/marketplace/actions/maximize-build-disk-space) which can recover space and consolidate it in a temp lvm disk. 

I left 10G of space for the root (for the git repo, deps and vagrant boxes) and mounted the remaining consolidated space to the `/var/lib/libvirt/images`  which leaves about 75G of free space.

```
Available storage:
Filesystem                   Size  Used Avail Use% Mounted on
/dev/root                     73G   63G   10G  87% /
tmpfs                        7.9G  172K  7.9G   1% /dev/shm
tmpfs                        3.2G  1.1M  3.2G   1% /run
tmpfs                        5.0M     0  5.0M   0% /run/lock
/dev/sdb15                   105M  6.1M   99M   6% /boot/efi
/dev/sda1                     74G   70G  100M 100% /mnt
tmpfs                        1.6G   12K  1.6G   1% /run/user/1001
/dev/mapper/buildvg-buildlv   76G   24K   76G   1% /var/lib/libvirt/images
```

Ran a few build and it's holding pretty well!

Fixes #293 