### PR TITLE
Update PBS Storage Encryption Key Format/Parsing

### DIFF
--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -299,7 +299,7 @@ from ansible.module_utils.pvesh import ProxmoxShellError
 import ansible.module_utils.pvesh as pvesh
 import re
 import json
-from json import JSONDecodeError, dumps as parse_json
+from json import JSONDecodeError, loads as parse_json, dumps as to_json
 
 
 class ProxmoxStorage(object):
@@ -355,7 +355,9 @@ class ProxmoxStorage(object):
                                           "'backup' content type.")
             try:
                 if self.encryption_key not in ["autogen", None]:
-                    self.encryption_key = parse_json(self.encryption_key)
+                    if isinstance(self.encryption_key, dict):
+                        self.encryption_key = to_json(self.encryption_key)
+                    parse_json(self.encryption_key)
             except JSONDecodeError:
                 self.module.fail_json(msg=("encryption_key needs to be valid "
                                            "JSON or set to 'autogen'."))

--- a/library/proxmox_storage.py
+++ b/library/proxmox_storage.py
@@ -299,7 +299,7 @@ from ansible.module_utils.pvesh import ProxmoxShellError
 import ansible.module_utils.pvesh as pvesh
 import re
 import json
-from json import JSONDecodeError, loads as parse_json
+from json import JSONDecodeError, dumps as parse_json
 
 
 class ProxmoxStorage(object):
@@ -355,7 +355,7 @@ class ProxmoxStorage(object):
                                           "'backup' content type.")
             try:
                 if self.encryption_key not in ["autogen", None]:
-                    parse_json(self.encryption_key)
+                    self.encryption_key = parse_json(self.encryption_key)
             except JSONDecodeError:
                 self.module.fail_json(msg=("encryption_key needs to be valid "
                                            "JSON or set to 'autogen'."))
@@ -578,7 +578,7 @@ def main():
                            "zfspool", "btrfs", "pbs", "cifs"]),
         # Remaining PVE API arguments (depending on type) past this point
         datastore=dict(default=None, type='str', required=False),
-        encryption_key=dict(default=None, type='str', required=False, no_log=True),
+        encryption_key=dict(default=None, type='raw', required=False, no_log=True),
         fingerprint=dict(default=None, type='str', required=False),
         master_pubkey=dict(default=None, type='str', required=False),
         password=dict(default=None, type='str', required=False, no_log=True),


### PR DESCRIPTION
Followup on #307 

So... when passing a variable like this in the role:
```
encryption_key: '{"kdf": null, "created": "2022-09-07T08:46:13+02:00", "modified": "2022-09-07T08:46:13+02:00", "data": "xxx", "fingerprint": "xxx"}'
```
it ends up as the following string in the proxmox_storage.py lib:
```
"{'kdf': None, 'created': '2022-09-07T08:46:13+02:00', 'modified': '2022-09-07T08:46:13+02:00', 'data': 'xxx', 'fingerprint': 'xxx'}"
```
which crashes since it's no longer a valid JSON.
```
"msg": "encryption_key needs to be valid JSON or set to 'autogen'."
```
If we change the `encryption_key` parameter to `raw` instead of `string`, it won't alter the format/content of the json string. After that we parse the `raw` json object to a string if it's not autogen and send that to the PVE api.

- I tested with 'autogen' and it works properly
- I tested with an invalid json and it fails with the proper error message
- I tested with a valid json encryption key and it passed