### PR TITLE
Populate pve_cluster_ssh_addrs correctly on Ansible 2.19

### DIFF
--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -1,14 +1,13 @@
 ---
 - name: Gather distribution specific variables
-  include_vars: "debian-{{ ansible_distribution_release }}.yml"
+  ansible.builtin.include_vars: "debian-{{ ansible_distribution_release }}.yml"
 
 - name: Ensure pve_cluster_addr0 is in the host facts
-  set_fact:
+  ansible.builtin.set_fact:
     pve_cluster_addr0: "{{ pve_cluster_addr0 }}"
 
 - name: Calculate list of SSH addresses
-  set_fact:
+  ansible.builtin.set_fact:
     pve_cluster_ssh_addrs: >-
-      ["{{ ansible_fqdn }}", "{{ ansible_hostname }}",
-      "{{ pve_cluster_addr0 }}",
-      {% if pve_cluster_addr1 is defined %}"{{ pve_cluster_addr1 }}"{% endif %}]
+      {{ [ansible_fqdn, ansible_hostname, pve_cluster_addr0,
+          pve_cluster_addr1 | default()] | unique | select }}


### PR DESCRIPTION
Ansible 2.19 appears to introduce a bug where `pve_cluster_ssh_addrs` ends up not getting converted to a list. We change the templating string here to be a list, and then just remove empty values (namely for `pve_cluster_addr1`). Bonus points, we also remove duplicates now I guess (mainly if fqdn and hostname are the same).

Fixes #323.
