### PR TITLE
Fix package lookup error in non-English locale

### DIFF
--- a/library/collect_kernel_info.py
+++ b/library/collect_kernel_info.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import glob
+import os
 import subprocess
 
 from ansible.module_utils.basic import AnsibleModule
@@ -39,12 +40,14 @@ def main():
     booted_kernel_packages = ""
     old_kernel_packages = []
     if params['lookup_packages']:
+        dpkg_env = dict(os.environ)
+        dpkg_env["LC_ALL"] = "C"
         for kernel in kernels:
             # Identify the currently booted kernel and unused old kernels by
             # querying which packages own directories in /lib/modules
             try:
                 sp = subprocess.run(["dpkg-query", "-S", kernel],
-                                    check=True, capture_output=True)
+                                    check=True, capture_output=True, env=dpkg_env)
             except subprocess.CalledProcessError as e:
                 # Ignore errors about directories not associated with a package
                 if e.stderr.startswith(b"dpkg-query: no path found matching"):

--- a/module_utils/pvesh.py
+++ b/module_utils/pvesh.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import json
+import os
 import re
 
 from ansible.module_utils._text import to_text
@@ -31,7 +32,9 @@ def run_command(handler, resource, **params):
         for value in values:
             command += ["--{}".format(parameter), "{}".format(value)]
 
-    pipe = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd_env = dict(os.environ)
+    cmd_env["LC_ALL"] = "C"
+    pipe = subprocess.Popen(command, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (result, stderr) = pipe.communicate()
     result = to_text(result)
     stderr = to_text(stderr).splitlines()


### PR DESCRIPTION
Ensure an English locale is used for commands that have or are likely to have their output compared against a string.

Resolves the user-facing run error in #331 (the underlying logic error described may or may not still exist, but doesn't result in a run error).
