### PR TITLE
"Fix: Add missing '| bool' filter to pve_cluster_enabled in groups task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -288,7 +288,7 @@
     state: "{{ item.state | default('present') }}"
     comment: "{{ item.comment | default(omit) }}"
   with_items: "{{ pve_groups }}"
-  when: "not pve_cluster_enabled or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
+  when: "not pve_cluster_enabled | bool or (pve_cluster_enabled | bool and inventory_hostname == _init_node)"
 
 - name: Configure Proxmox user accounts
   proxmox_user:


### PR DESCRIPTION
The groups task condition was missing the '| bool' filter on the first
pve_cluster_enabled check, causing it to evaluate incorrectly when the
variable is a string. This brings it in line with the roles and users
tasks which already have this filter.

The issue was the groups condition was always evaluating to false.  Therefore my user creation was failing as the group did not exist.  The condition was different from both the roles and user condition, and this brings it to be the same.

After this change the groups were created as expected.