### PR TITLE
Auto install the package python3-debian needed by the module deb822

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,6 +164,7 @@
         components: "{{ pve_repository.components }}"
         signed_by: /etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg
         state: present
+        install_python_debian: true
       register: _pve_repo
 
     - name: Add Proxmox Ceph repository
@@ -175,6 +176,7 @@
         components: "{{ pve_ceph_repository.components }}"
         signed_by: /etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg
         state: present
+        install_python_debian: true
       register: _pve_ceph_repo
       when: "pve_ceph_enabled | bool"
 

--- a/tasks/remove_enterprise_repos.yml
+++ b/tasks/remove_enterprise_repos.yml
@@ -19,6 +19,7 @@
     uris: "{{ item.uris }}"
     suites: "{{ ansible_distribution_release }}"
     components: "{{ item.components }}"
+    install_python_debian: true
   loop:
     - { name: 'pve-enterprise', uris: 'https://enterprise.proxmox.com/debian/pve', components: ['pve-enterprise'] }
     - { name: 'ceph', uris: 'https://enterprise.proxmox.com/debian/{{ pve_ceph_debian_component }}', components: ['enterprise'] }


### PR DESCRIPTION
Currently, to run this role, one host requirement is `python`, which is fine

But there is an issue when using Ansible > 12 because the module `ansible.builtin.deb822_repository`  requires `python3-debian`

Using `pve_extra_packages` will not works since `deb822_repository` is used before so it would be nice to use the [install_python_debian](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/deb822_repository_module.html#parameter-install_python_debian) parameter to automatically handle this dependency for this module

If you think this requirement should not be handled by this role or by this way, let me know and/or close this PR



