### PR TITLE
fix: use explicit boolean condition

### DIFF
--- a/tasks/realms_config.yml
+++ b/tasks/realms_config.yml
@@ -46,7 +46,7 @@
     owner: root
     group: www-data
     mode: "0700"
-  when: pve_ldap_realms_with_bind_pw | length
+  when: pve_ldap_realms_with_bind_pw | length > 0
 
 - name: Ensure ldap-based realm secret files exists
   ansible.builtin.file:


### PR DESCRIPTION
Make the conditional return an explicit boolean (needed for ansible >=2.19)

Error occur using ansible >= 2.19 when `pve_domains_cfg` doesn't contain type `ad` and `ldap`:

```logs
TASK [lae.proxmox : Ensure /etc/pve/priv/realm/ exists] ********************************************************************************************************************************************************************************************************************************
[ERROR]: Task failed: Conditional result (False) was derived from value of type 'int' at 'lae.proxmox/tasks/realms_config.yml:49:9'. Conditionals must have a boolean result.

Task failed.
Origin: lae.proxmox/tasks/realms_config.yml:42:3

40                          | selectattr('attributes.bind_password', 'defined') }}
41
42 - name: Ensure /etc/pve/priv/realm/ exists
     ^ column 3

<<< caused by >>>

Conditional result (False) was derived from value of type 'int' at 'lae.proxmox/tasks/realms_config.yml:49:9'. Conditionals must have a boolean result.
Origin:lae.proxmox/tasks/realms_config.yml:49:9

47     group: www-data
48     mode: "0700"
49   when: pve_ldap_realms_with_bind_pw | length
           ^ column 9

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [masked]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (False) was derived from value of type 'int' at 'lae.proxmox/tasks/realms_config.yml:49:9'. Conditionals must have a boolean result."}
```