### PR TITLE
Add 'ceph-volume' to default installation packages for ceph

### DIFF
--- a/tasks/identify_needed_packages.yml
+++ b/tasks/identify_needed_packages.yml
@@ -14,7 +14,7 @@
 
 - name: Stage Ceph packages if Ceph is enabled
   ansible.builtin.set_fact:
-    _pve_install_packages: "{{ _pve_install_packages | union(['ceph', 'ceph-common', 'ceph-mds', 'ceph-fuse', 'gdisk']) }}"
+    _pve_install_packages: "{{ _pve_install_packages | union(['ceph', 'ceph-common', 'ceph-mds', 'ceph-fuse', 'ceph-volume', 'gdisk']) }}"
   when: "pve_ceph_enabled | bool"
 
 - name: Stage any extra packages the user has specified


### PR DESCRIPTION
Well, there is an entire module called pve_ceph_volume, but the package is not installed automatically. (ceph-volume is also not installed by apt as a dependency in any form.)