### PR TITLE
remove non existing kernel module (pve>=8)

### DIFF
--- a/tasks/pcie_passthrough.yml
+++ b/tasks/pcie_passthrough.yml
@@ -80,7 +80,6 @@
           vfio
           vfio_iommu_type1
           vfio_pci
-          vfio_virqfd
 
     - name: Modify modules list for GVT-g
       ansible.builtin.blockinfile:


### PR DESCRIPTION
The kernel module `vfio_virqfd` is no longer a module in Proxmox >=8

Loading it, throw an error at boot `modprobe: FATAL: Module vfio_virqfd not found`

Nothing breaking but just noisy