### PR TITLE
IC-4244: Add meta-dev.yml with squad ownership and maintainer info

### DIFF
--- a/meta-dev.yml
+++ b/meta-dev.yml
@@ -1,0 +1,11 @@
+names:
+  service: infra-bm-role-proxmox
+
+project:
+  squad: infra-bare-metal-squad
+  primary_maintainer: daan
+  secondary_maintainer:
+  public_api: false
+  private_api: false
+  dependencies: []
+  processes_pii: false


### PR DESCRIPTION
## Summary
- Added `meta-dev.yml` file following ADR-8 Service Metadata Specification
- Set squad: `infra-bare-metal-squad`
- Set primary_maintainer: `daan`
- Configured standard service metadata fields for GitHub repo access control tooling

## Changes
- ✅ Created `meta-dev.yml` with required fields
- ✅ Squad assignment: `infra-bare-metal-squad`
- ✅ Primary maintainer: `daan`
- ✅ Standard metadata fields (public_api, private_api, dependencies, processes_pii)

## Context
Part of IC-4244 initiative to ensure all bare metal repositories have proper meta-dev.yml files for access control and ownership tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)