### PR TITLE
Add meta-dev.yml with squad ownership

### DIFF
--- a/meta-dev.yml
+++ b/meta-dev.yml
@@ -1,0 +1,10 @@
+names:
+  service: infra-bm-role-proxmox
+
+project:
+  squad: infra-bare-metal-squad
+  primary_maintainer: daan
+  public_api: false
+  private_api: false
+  dependencies: []
+  processes_pii: false


### PR DESCRIPTION
This PR adds meta-dev.yml file following ADR-8 Service Metadata Specification.

Changes:
- Set squad: infra-bare-metal-squad
- Set primary_maintainer: daan
- Configure service metadata for repo access control tooling

Related to IC-4244