### PR TITLE
Fix #352: Disable logging of secrets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ pve_storages: [] # List of storages to manage in PVE. See section on Storage Man
 pve_metric_servers: [] # List of metric servers to configure in PVE.
 pve_datacenter_cfg: {} # Dictionary to configure the PVE datacenter.cfg config file.
 pve_domains_cfg: [] # List of realms to use as authentication sources in the PVE domains.cfg config file.
-pve_no_log: false # Set this to true in production to prevent leaking of storage credentials in run logs. (may be used in other tasks in the future)
+pve_no_log: true # Set this to false if you need to debug the content via run logs for certain configuration tasks, such as for storage or SSL.
 ```
 
 To enable clustering with this role, configure the following variables appropriately:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,4 +75,4 @@ pve_metric_servers: []
 pve_ssh_port: 22
 pve_manage_ssh: true
 pve_hooks: {}
-pve_no_log: false
+pve_no_log: true

--- a/tasks/ssl_config.yml
+++ b/tasks/ssl_config.yml
@@ -4,6 +4,7 @@
     content: "{{ item.content }}"
     dest: "{{ item.dest }}"
     mode: "0640"
+  no_log: "{{ pve_no_log }}"
   with_items:
     - dest: "/etc/ssl/pveproxy-ssl.key"
       content: "{{ pve_ssl_private_key }}"


### PR DESCRIPTION
Fixes #352.

There are probably some people who might consider this a breaking change but I'd say the majority would not.

- **fix: set no_log on SSL configuration task**
- **feat: update pve_no_log to true (secure default)**
