### PR TITLE
refactor: Add no_log option to SSL config task

### DIFF
--- a/tasks/ssl_config.yml
+++ b/tasks/ssl_config.yml
@@ -4,6 +4,7 @@
     content: "{{ item.content }}"
     dest: "{{ item.dest }}"
     mode: "0640"
+  no_log: true
   with_items:
     - dest: "/etc/ssl/pveproxy-ssl.key"
       content: "{{ pve_ssl_private_key }}"


### PR DESCRIPTION
Display certificates content in Ansible stdout can be a serious security issue when run in CI/CD