### PR TITLE
fix: Custom repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ pve_repository:
   suites: "{{ ansible_distribution_release }}"
   components: pve-no-subscription
   signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
+  key: "proxmox-release-{{ ansible_distribution_release }}.gpg"
 # pve_repository_line: ""
 pve_remove_subscription_warning: true
 pve_extra_packages: []
@@ -40,6 +41,7 @@ pve_ceph_repository:
   suites: "{{ ansible_distribution_release }}"
   components: "{{ pve_ceph_debian_component }}"
   signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
+  key: "proxmox-release-{{ ansible_distribution_release }}.gpg"
 # pve_ceph_repository_line: ""
 pve_ceph_network: >-
   {{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ pve_repository:
   uris: http://download.proxmox.com/debian/pve
   suites: "{{ ansible_distribution_release }}"
   components: pve-no-subscription
+  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
 # pve_repository_line: ""
 pve_remove_subscription_warning: true
 pve_extra_packages: []
@@ -38,6 +39,7 @@ pve_ceph_repository:
   uris: http://download.proxmox.com/debian/ceph-{{ pve_ceph_default_version }}
   suites: "{{ ansible_distribution_release }}"
   components: "{{ pve_ceph_debian_component }}"
+  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
 # pve_ceph_repository_line: ""
 pve_ceph_network: >-
   {{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,7 +124,10 @@
     src: "{{ pve_repository.key }}"
     dest: "{{ pve_repository.signed_by }}"
     mode: "0644"
-  when: "ansible_distribution_major_version | int >= 12"
+  when:
+    - ansible_distribution_major_version | int >= 12
+    - pve_repository.key is defined
+    - pve_repository.key | length > 0
 
 - name: Trust Ceph packaging key on Debian >= 12
   ansible.builtin.copy:
@@ -134,6 +137,8 @@
   when:
     - ansible_distribution_major_version | int >= 12
     - pve_ceph_enabled | bool
+    - pve_ceph_repository.key is defined
+    - pve_ceph_repository.key | length > 0
 
 - name: Remove os-prober package
   ansible.builtin.apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,12 +119,21 @@
     state: present
   when: "ansible_distribution_major_version | int < 12"
 
-- name: Trust Proxmox' packaging key on Debian >= 12
+- name: Trust PVE packaging key on Debian >= 12
   ansible.builtin.copy:
-    src: "proxmox-release-{{ ansible_distribution_release }}.gpg"
-    dest: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
+    src: "{{ pve_repository.key }}"
+    dest: "{{ pve_repository.signed_by }}"
     mode: "0644"
   when: "ansible_distribution_major_version | int >= 12"
+
+- name: Trust Ceph packaging key on Debian >= 12
+  ansible.builtin.copy:
+    src: "{{ pve_ceph_repository.key }}"
+    dest: "{{ pve_ceph_repository.signed_by }}"
+    mode: "0644"
+  when:
+    - ansible_distribution_major_version | int >= 12
+    - pve_ceph_enabled | bool
 
 - name: Remove os-prober package
   ansible.builtin.apt:

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -1,19 +1,36 @@
 ---
-- name: Convert pve_repository_line to pve_repository format
+- name: Split pve_repository_line into parts
   ansible.builtin.set_fact:
-    pve_repository:
-      uris: "{{ (pve_repository_line | trim | split(' '))[1] }}"
-      suites: "{{ (pve_repository_line | trim | split(' '))[2] }}"
-      components: "{{ (pve_repository_line | trim | split(' '))[3:] }}"
+    _pve_repo_parts: "{{ pve_repository_line | trim | split(' ') }}"
   when:
     - pve_repository_line is defined
 
+- name: Convert pve_repository_line to pve_repository format
+  ansible.builtin.set_fact:
+    pve_repository: >-
+      {{ pve_repository | default({}) | combine({
+        'uris': _pve_repo_parts[1],
+        'suites': _pve_repo_parts[2],
+        'components': _pve_repo_parts[3:]
+      }) }}
+  when:
+    - pve_repository_line is defined
+
+- name: Split pve_ceph_repository_line into parts
+  ansible.builtin.set_fact:
+    _pve_ceph_repo_parts: "{{ pve_ceph_repository_line | trim | split(' ') }}"
+  when:
+    - pve_ceph_repository_line is defined
+    - pve_ceph_enabled | bool
+
 - name: Convert pve_ceph_repository_line to pve_ceph_repository format
   ansible.builtin.set_fact:
-    pve_ceph_repository:
-      uris: "{{ (pve_ceph_repository_line | trim | split(' '))[1] }}"
-      suites: "{{ (pve_ceph_repository_line | trim | split(' '))[2] }}"
-      components: "{{ (pve_ceph_repository_line | trim | split(' '))[3:] }}"
+    pve_ceph_repository: >-
+      {{ pve_ceph_repository | default({}) | combine({
+        'uris': _pve_ceph_repo_parts[1],
+        'suites': _pve_ceph_repo_parts[2],
+        'components': _pve_ceph_repo_parts[3:]
+      }) }}
   when:
     - pve_ceph_repository_line is defined
     - pve_ceph_enabled | bool
@@ -25,7 +42,7 @@
     uris: "{{ pve_repository.uris }}"
     suites: "{{ pve_repository.suites }}"
     components: "{{ pve_repository.components }}"
-    signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
+    signed_by: "{{ pve_repository.signed_by }}"
     state: present
     enabled: true
   register: _pve_repo
@@ -49,7 +66,7 @@
     uris: "{{ pve_ceph_repository.uris }}"
     suites: "{{ pve_ceph_repository.suites }}"
     components: "{{ pve_ceph_repository.components }}"
-    signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
+    signed_by: "{{ pve_ceph_repository.signed_by }}"
     state: present
     enabled: true
   register: _pve_ceph_repo


### PR DESCRIPTION
GPG key deployment tasks ignored the pve_repository and pve_ceph_repository variables, making it impossible to use a custom repository with its own signing key.
The key source and destination were hardcoded while signed_by was already configurable on the apt side.
