### PR TITLE
Add option sync_extra_opts in pve_domains_cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ pve_domains_cfg:
   - name: ldap
     type: ldap
     sync: true
+    sync_extra_opts: "--remove-vanished entry --scope both"
     attributes:
       comment: LDAP authentication
       base_dn: CN=Users,dc=yourdomain,dc=com

--- a/README.md
+++ b/README.md
@@ -496,8 +496,10 @@ You can set realms / domains as authentication sources in the `domains.cfg` conf
 If this file is not present, only the `Linux PAM` and `Proxmox VE authentication server` realms
 are available. Supported types are `pam`, `pve`, `ad` and `ldap`.
 It’s possible to automatically sync users and groups for LDAP-based realms (LDAP & Microsoft Active Directory) with `sync: true`.
+
 You can also specify extra paremeters for the realm sync using `sync_extra_opts` in the `pve_domains_cfg` config. These opts are appended to the realm sync command.
-The available options are defined in the `pveum` cli utility docs: https://pve.proxmox.com/pve-docs/pveum.1.html#cli_pveum_realm_sync
+The available options are defined in the [Proxmox pveum cli util manual][pveum-realm-sync]
+
 One realm should have the `default: 1` property to mark it as the default:
 
 ```
@@ -1019,3 +1021,4 @@ Antoine Thys ([@thystips](https://github.com/thystips)) - Metric Servers Support
 [datacenter-cfg]: https://pve.proxmox.com/wiki/Manual:_datacenter.cfg
 [ceph_volume]: https://github.com/ceph/ceph-ansible/blob/master/library/ceph_volume.py
 [ha-group]: https://pve.proxmox.com/wiki/High_Availability#ha_manager_groups
+[pveum-realm-sync]: https://pve.proxmox.com/pve-docs/pveum.1.html#cli_pveum_realm_sync

--- a/README.md
+++ b/README.md
@@ -496,6 +496,8 @@ You can set realms / domains as authentication sources in the `domains.cfg` conf
 If this file is not present, only the `Linux PAM` and `Proxmox VE authentication server` realms
 are available. Supported types are `pam`, `pve`, `ad` and `ldap`.
 It’s possible to automatically sync users and groups for LDAP-based realms (LDAP & Microsoft Active Directory) with `sync: true`.
+You can also specify extra paremeters for the realm sync using `sync_extra_opts` in the `pve_domains_cfg` config. These opts are appended to the realm sync command.
+The available options are defined in the `pveum` cli utility docs: https://pve.proxmox.com/pve-docs/pveum.1.html#cli_pveum_realm_sync
 One realm should have the `default: 1` property to mark it as the default:
 
 ```

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -108,6 +108,7 @@
               \\g<space>step emit\n}"
           loop: "{{ pve_ceph_crush_rules }}"
           register: _crushmap
+          when: not ansible_check_mode
 
         - name: Validate and compress new crushmap
           ansible.builtin.command: crushtool -c crush_map_decompressed -o new_crush_map_compressed

--- a/tasks/realms_sync.yml
+++ b/tasks/realms_sync.yml
@@ -12,7 +12,7 @@
   changed_when: false
 
 - name: "Sync ldap-based realm {{ pve_ldap_realm.name }}"
-  ansible.builtin.command: "pveum realm sync {{ pve_ldap_realm.name }}"
+  ansible.builtin.command: "pveum realm sync {{ pve_ldap_realm.name }}{% if pve_ldap_realm.sync_extra_opts is defined %} {{ pve_ldap_realm.sync_extra_opts }}{% endif %}"
   changed_when: false
 
 - name: Get post-sync state of groups


### PR DESCRIPTION
When configuring `pve_domains_cfg` with LDAP I got this error message.

```
TASK [lae.proxmox : Sync ldap-based realm ldap] ******************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [proxmox-01]: FAILED! => {"changed": false, "cmd": ["pveum", "realm", "sync", "ldap"], "delta": "0:00:00.443123", "end": "2026-03-20 23:47:20.344693", "msg": "non-zero return code", "rc": 255, "start": "2026-03-20 23:47:19.901570", "stderr": "400 Parameter verification failed.\nscope: Not passed as parameter and not defined in realm default sync options.\npveum realm sync <realm> [OPTIONS]", "stderr_lines": ["400 Parameter verification failed.", "scope: Not passed as parameter and not defined in realm default sync options.", "pveum realm sync <realm> [OPTIONS]"], "stdout": "", "stdout_lines": []}
```

I added an way to define extra options for the sync command.

Under `pve_domains_cfg` I can define `sync_extra_opts` and if this var is defined they are passed in the `Sync ldap-based realm ldap` task.

This works for me and is nicely backwards compatible and not intrusive.