### PR TITLE
feat: support one node cluster

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,6 @@
   with_items: "{{ groups[pve_group] }}"
   when: "pve_cluster_enabled | bool"
 
-- name: Ensure that group has more than one host to enable PVE clustering
-  ansible.builtin.assert:
-    that:
-      - "groups[pve_group] | length | int >= 2"
-    msg: "Clustering is enabled for {{ pve_group }} but does not meet the \
-          minimum host requirement of 2. Please either remove/disable \
-          pve_cluster_enabled, or update your inventory as needed."
-  when: "pve_cluster_enabled | bool"
-
 - name: Ensure this host is in the group specified
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
## Description

Remove the minimum two-node requirement for creating a cluster.
This allows creating a PVE cluster with a single node and adding more nodes later.