### PR TITLE
refactor: fix ansible_facts deprecation warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,10 @@ pve_group: proxmox
 # Proxmox PVE Repository
 pve_repository:
   uris: http://download.proxmox.com/debian/pve
-  suites: "{{ ansible_distribution_release }}"
+  suites: "{{ ansible_facts['distribution_release'] }}"
   components: pve-no-subscription
-  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
-  key: "proxmox-release-{{ ansible_distribution_release }}.gpg"
+  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_facts['distribution_release'] }}.gpg"
+  key: "proxmox-release-{{ ansible_facts['distribution_release'] }}.gpg"
 # pve_repository_line: ""
 pve_remove_subscription_warning: true
 pve_extra_packages: []
@@ -38,13 +38,13 @@ pve_ceph_enabled: false
 # Proxmox Ceph Repository
 pve_ceph_repository:
   uris: http://download.proxmox.com/debian/ceph-{{ pve_ceph_default_version }}
-  suites: "{{ ansible_distribution_release }}"
+  suites: "{{ ansible_facts['distribution_release'] }}"
   components: "{{ pve_ceph_debian_component }}"
-  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_distribution_release }}.gpg"
-  key: "proxmox-release-{{ ansible_distribution_release }}.gpg"
+  signed_by: "/etc/apt/trusted.gpg.d/proxmox-release-{{ ansible_facts['distribution_release'] }}.gpg"
+  key: "proxmox-release-{{ ansible_facts['distribution_release'] }}.gpg"
 # pve_ceph_repository_line: ""
 pve_ceph_network: >-
-  {{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) |
+  {{ (ansible_facts['default_ipv4'].network + '/' + ansible_facts['default_ipv4'].netmask) |
     ansible.utils.ipaddr('net') }}
 pve_ceph_nodes: "{{ pve_group }}"
 pve_ceph_mon_group: "{{ pve_group }}"
@@ -60,9 +60,9 @@ pve_cluster_enabled: no
 pve_cluster_clustername: "{{ pve_group }}"
 pve_manage_hosts_enabled: yes
 pve_cluster_addr0: >-
-  {{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined
-    else ansible_default_ipv6.address if ansible_default_ipv6.address is defined }}
-# pve_cluster_addr1: "{{ ansible_eth1.ipv4.address }}
+  {{ ansible_facts['default_ipv4'].address if ansible_facts['default_ipv4'].address is defined
+    else ansible_facts['default_ipv6'].address if ansible_facts['default_ipv6'].address is defined }}
+# pve_cluster_addr1: "{{ ansible_facts['eth1'].ipv4.address }}
 # pve_cluster_addr0_priority: 0
 # pve_cluster_addr1_priority: 1
 pve_datacenter_cfg: {}

--- a/tasks/ceph.yml
+++ b/tasks/ceph.yml
@@ -13,7 +13,7 @@
     - name: Create initial Ceph monitor
       ansible.builtin.command: "pveceph mon create"
       args:
-        creates: "/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/"
+        creates: "/var/lib/ceph/mon/ceph-{{ ansible_facts['hostname'] }}/"
       register: _ceph_initial_mon
 
     - name: Fail if initial monitor creation failed
@@ -25,7 +25,7 @@
 - name: Create additional Ceph monitors
   ansible.builtin.command: "pveceph mon create"
   args:
-    creates: "/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/"
+    creates: "/var/lib/ceph/mon/ceph-{{ ansible_facts['hostname'] }}/"
   when:
     - "inventory_hostname != groups[pve_ceph_mon_group][0]"
     - "inventory_hostname in groups[pve_ceph_mon_group]"
@@ -33,7 +33,7 @@
 - name: Create additional Ceph managers
   ansible.builtin.command: "pveceph mgr create"
   args:
-    creates: "/var/lib/ceph/mgr/ceph-{{ ansible_hostname }}/"
+    creates: "/var/lib/ceph/mgr/ceph-{{ ansible_facts['hostname'] }}/"
   when: "inventory_hostname in groups[pve_ceph_mgr_group]"
 
 - block:
@@ -183,7 +183,7 @@
 - name: Create Ceph MDS servers
   ansible.builtin.command: pveceph mds create
   args:
-    creates: "/var/lib/ceph/mds/ceph-{{ ansible_hostname }}"
+    creates: "/var/lib/ceph/mds/ceph-{{ ansible_facts['hostname'] }}"
   register: _ceph_mds_create
   when: "inventory_hostname in groups[pve_ceph_mds_group] and pve_ceph_fs | length > 0"
 
@@ -263,7 +263,7 @@
     path: "{{ item.mountpoint }}"
     src: |-
       {% for h in groups[pve_ceph_mon_group] -%}
-      {{ hostvars[h].ansible_all_ipv4_addresses | ansible.utils.ipaddr(pve_ceph_network) | first -}}
+      {{ hostvars[h].ansible_facts['all_ipv4_addresses'] | ansible.utils.ipaddr(pve_ceph_network) | first -}}
       {{ loop.last | ternary("", ",") -}}
       {% endfor %}:/
     fstype: "ceph"

--- a/tasks/kernel_module_cleanup.yml
+++ b/tasks/kernel_module_cleanup.yml
@@ -53,7 +53,7 @@
   notify: update-grub
   when: >
     (not pve_pcie_passthrough_enabled | bool) or
-    ((not 'GenuineIntel' in ansible_processor | unique) and
+    ((not 'GenuineIntel' in ansible_facts['processor'] | unique) and
     (not pve_iommu_passthrough_mode | bool) and
     (not pve_mediated_devices_enabled | bool) and
     (not pve_pci_device_ids | length > 0))

--- a/tasks/load_variables.yml
+++ b/tasks/load_variables.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather distribution specific variables
-  ansible.builtin.include_vars: "debian-{{ ansible_distribution_release }}.yml"
+  ansible.builtin.include_vars: "debian-{{ ansible_facts['distribution_release'] }}.yml"
 
 - name: Ensure pve_cluster_addr0 is in the host facts
   ansible.builtin.set_fact:
@@ -9,5 +9,5 @@
 - name: Calculate list of SSH addresses
   ansible.builtin.set_fact:
     pve_cluster_ssh_addrs: >-
-      {{ [ansible_fqdn, ansible_hostname, pve_cluster_addr0,
+      {{ [ansible_facts['fqdn'], ansible_facts['hostname'], pve_cluster_addr0,
           pve_cluster_addr1 | default()] | unique | select }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,8 +44,8 @@
     content: "\
       {% for host in groups[pve_group] %}\
         {{ hostvars[host].pve_cluster_addr0 }}
-        {{ hostvars[host].ansible_fqdn }}
-        {{ hostvars[host].ansible_hostname }}
+        {{ hostvars[host].ansible_facts['fqdn'] }}
+        {{ hostvars[host].ansible_facts['hostname'] }}
 
 
       {% endfor %}"
@@ -80,13 +80,13 @@
   vars:
     _correct_line: "\
       {{ hostvars[item].pve_cluster_addr0 }}
-      {{ hostvars[item].ansible_fqdn }}
-      {{ hostvars[item].ansible_hostname }}"
+      {{ hostvars[item].ansible_facts['fqdn'] }}
+      {{ hostvars[item].ansible_facts['hostname'] }}"
     _correct_ip: "{{ hostvars[item].pve_cluster_addr0 }}"
     _match_hosts: >-
       [
-        "{{ hostvars[item].ansible_fqdn }}",
-        "{{ hostvars[item].ansible_hostname }}"
+        "{{ hostvars[item].ansible_facts['fqdn'] }}",
+        "{{ hostvars[item].ansible_facts['hostname'] }}"
       ]
   when: "pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
@@ -99,11 +99,11 @@
       {# Match at least one whitespace, and any non-hostname names #}\
       (\\s+.*)*\\s\
       {# Match either our fqdn or hostname #}\
-      ({{ ansible_fqdn | regex_escape() }}|{{ ansible_hostname | regex_escape() }})\
+      ({{ ansible_facts['fqdn'] | regex_escape() }}|{{ ansible_facts['hostname'] | regex_escape() }})\
       {# Require there be a word boundary at the end of the name(s). #}\
       {# This can be any whitespace, or end-of-line. #}\
       (\\s+.*|\\s*)$"
-    line: "{{ hostvars[inventory_hostname].pve_cluster_addr0 }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ hostvars[inventory_hostname].pve_cluster_addr0 }} {{ ansible_facts['fqdn'] }} {{ ansible_facts['hostname'] }}"
     backup: yes
   when: "not pve_cluster_enabled | bool and pve_manage_hosts_enabled | bool"
 
@@ -117,7 +117,7 @@
     data: "{{ lookup('file', pve_release_key) }}"
     id: "{{ pve_release_key_id }}"
     state: present
-  when: "ansible_distribution_major_version | int < 12"
+  when: "ansible_facts['distribution_major_version'] | int < 12"
 
 - name: Trust PVE packaging key on Debian >= 12
   ansible.builtin.copy:
@@ -125,7 +125,7 @@
     dest: "{{ pve_repository.signed_by }}"
     mode: "0644"
   when:
-    - ansible_distribution_major_version | int >= 12
+    - ansible_facts['distribution_major_version'] | int >= 12
     - pve_repository.key is defined
     - pve_repository.key | length > 0
 
@@ -135,7 +135,7 @@
     dest: "{{ pve_ceph_repository.signed_by }}"
     mode: "0644"
   when:
-    - ansible_distribution_major_version | int >= 12
+    - ansible_facts['distribution_major_version'] | int >= 12
     - pve_ceph_enabled | bool
     - pve_ceph_repository.key is defined
     - pve_ceph_repository.key | length > 0

--- a/tasks/pcie_passthrough.yml
+++ b/tasks/pcie_passthrough.yml
@@ -4,7 +4,7 @@
     dest: /etc/default/grub
     marker: "# {mark}: IOMMU default grub configuration (managed by ansible)."
     content: "\
-      {% if 'GenuineIntel' in ansible_processor %}GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX intel_iommu=on\"\n{% endif %}\
+      {% if 'GenuineIntel' in ansible_facts['processor'] %}GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX intel_iommu=on\"\n{% endif %}\
       {% if (pve_iommu_passthrough_mode | bool) %}GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX iommu=pt\"\n{% endif %}\
       {% if (pve_mediated_devices_enabled | bool) %}GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX i915.enable_gvt=1 i915.enable_guc=0\"\n{% endif %}\
       {% if (pve_pci_device_ids | length > 0) %}GRUB_CMDLINE_LINUX=\"$GRUB_CMDLINE_LINUX vfio-pci.ids={% for k in pve_pci_device_ids %}{{ k.id }}{% if k != (pve_pci_device_ids | last) %},{% endif %}{% endfor %}\"{% endif %}"
@@ -12,7 +12,7 @@
     mode: "0640"
   notify: update-grub
   when: >
-    ('GenuineIntel' in ansible_processor | unique) or
+    ('GenuineIntel' in ansible_facts['processor'] | unique) or
     (pve_iommu_passthrough_mode | bool) or
     (pve_mediated_devices_enabled | bool) or
     (pve_pci_device_ids | length > 0)

--- a/tests/group_vars/all
+++ b/tests/group_vars/all
@@ -1,7 +1,7 @@
 ---
 ansible_ssh_user: root
 
-pve_group: "{{ ansible_distribution_release }}cluster"
+pve_group: "{{ ansible_facts['distribution_release'] }}cluster"
 pve_extra_packages:
   - sl
 pve_check_for_kernel_update: false

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -23,7 +23,7 @@
       - "lxc.apparmor.profile = unconfined"
       - "lxc.mount.auto = proc:rw sys:rw cgroup-full:rw"
       - "lxc.cgroup.devices.allow = a *:* rmw"
-      - "lxc.mount.entry = /lib/modules/{{ ansible_kernel }} lib/modules/{{ ansible_kernel }} none bind,create=dir,ro 0 0"
+      - "lxc.mount.entry = /lib/modules/{{ ansible_facts['kernel'] }} lib/modules/{{ ansible_facts['kernel'] }} none bind,create=dir,ro 0 0"
 
 # Run the following within the containers in the inventory
 - hosts: all
@@ -41,8 +41,8 @@
         path: /etc/hosts
         line: "{{ item }}"
       with_items:
-        - "127.0.1.1    {{ ansible_fqdn }} {{ ansible_hostname }}"
-        - "10.22.33.44    {{ ansible_hostname }} {{ ansible_fqdn }}"
+        - "127.0.1.1    {{ ansible_facts['fqdn'] }} {{ ansible_facts['hostname'] }}"
+        - "10.22.33.44    {{ ansible_facts['hostname'] }} {{ ansible_facts['fqdn'] }}"
     - name: Update CA certificate store
       shell: update-ca-certificates
     - block:
@@ -83,7 +83,7 @@
                 flush_interval = "10s"
                 flush_jitter = "0s"
                 precision = ""
-                hostname = "{{ ansible_hostname }}"
+                hostname = "{{ ansible_facts['hostname'] }}"
                 omit_hostname = false
               [[inputs.socket_listener]]
                 service_address = "udp://127.0.0.1:8089"

--- a/tests/vagrant/group_vars/all
+++ b/tests/vagrant/group_vars/all
@@ -62,7 +62,7 @@ pve_storages:
     pool: vm-storage
     username: admin
     monhost:
-      - "{{ ansible_fqdn }}:6789"
+      - "{{ ansible_facts['fqdn'] }}:6789"
   - name: zfs1
     type: zfspool
     content: [ "images", "rootdir" ]

--- a/tests/vagrant/tasks/zpool_setup.yml
+++ b/tests/vagrant/tasks/zpool_setup.yml
@@ -2,4 +2,4 @@
   community.general.zpool_facts:
 - name: Create testpool ZFS pool
   ansible.builtin.command: zpool create testpool vdc
-  when: "'testpool' not in (ansible_zfs_pools | json_query('[].name'))"
+  when: "'testpool' not in (ansible_facts['zfs_pools'] | json_query('[].name'))"


### PR DESCRIPTION
### Summary

Currently, this role use some ansible facts without using `ansible_facts`, this cause issue when using `inject_facts_as_vars = False`, since these variables will not be defined.

This PR address this issue.